### PR TITLE
Remove "LTS" from the AMI release tag

### DIFF
--- a/packer/buildkite-ubuntu-15.04.json
+++ b/packer/buildkite-ubuntu-15.04.json
@@ -10,7 +10,7 @@
       "ami_description": "A docker host image based on Ubuntu 15.04",
       "ami_groups": ["all"],
       "tags": {
-        "Release": "15.04 LTS",
+        "Release": "15.04",
         "Docker": "1.6.2",
         "Docker-Compose": "1.3.1"
       }


### PR DESCRIPTION
According to [Ubuntu](https://wiki.ubuntu.com/LTS), 15.04 isn't an LTS release; 15.10 will be.