### PR TITLE
Fix missing escaping on `$DOCKER_HUB_AUTH`

### DIFF
--- a/buildkite-elastic.yml
+++ b/buildkite-elastic.yml
@@ -184,9 +184,9 @@ Resources:
             "/home/ubuntu/buildkite/hooks/environment":
               content: |
                 #!/bin/bash -eu
-                if [[ -n $DOCKER_HUB_AUTH ]] ; then
+                if [[ -n \$DOCKER_HUB_AUTH ]] ; then
                   echo "~~~ Overwriting /root/.dockercfg"
-                  echo $DOCKER_HUB_AUTH > /root/.dockercfg
+                  echo \$DOCKER_HUB_AUTH > /root/.dockercfg
                 fi
                 echo "~~~ Stopping existing docker containers"
                 if [[ \$(docker ps -q | wc -l) -gt 0 ]] ; then


### PR DESCRIPTION
Does what it says on the tin...

When running `make`, `cfoo` was complaining:

```
cfoo buildkite-elastic.yml mappings.yml > cloudformation.json
Failed to parse 'buildkite-elastic.yml':
Location: buildkite-elastic.yml line 190, column 5
Source: #!/bin/bash -eu
if [[ -n $DOCKER_HUB_AUTH ]] ; then
  echo "~~~ Overwriting /root/.dockercfg"
  echo $DOCKER_HUB_AUTH > /root/.dockercfg
fi
echo "~~~ Stopping existing docker containers"
if [[ \$(docker ps -q | wc -l) -gt 0 ]] ; then
  docker stop \$(docker ps -q)
fi

Cause: Extra input after last repetition at line 2 char 10.
`- Expected one of [ESCAPED_DOLLAR, LONE_BACKSLASH, EL, TEXT] at line 2 char 10.
   |- Expected "\\$", but got "$D" at line 2 char 10.
   |- Expected "\\", but got "$" at line 2 char 10.
   |- Failed to match sequence ('$(' (MAPPING / ATTRIBUTE_REFERENCE / FUNCTION_CALL / REFERENCE) ')') at line 2 char 10.
   |  `- Expected "$(", but got "$D" at line 2 char 10.
   `- Expected at least 1 of TEXT_CHARACTER at line 2 char 10.
      `- Failed to match [^\\\\$] at line 2 char 10.
```