### PR TITLE
Add ssh-agent

### DIFF
--- a/build/cloudformation.json
+++ b/build/cloudformation.json
@@ -360,6 +360,12 @@
                 "owner": "ubuntu",
                 "group": "ubuntu"
               },
+              "/lib/systemd/system/ssh-agent.service": {
+                "content": "[Unit]\nDescription=ssh-agent\nBefore=docker.service\n[Service]\nType=forking\nEnvironment=SSH_AUTH_SOCK=/ssh-agent\nExecStart=/usr/bin/ssh-agent -a $SSH_AUTH_SOCK\nExecStartPost=/usr/bin/ssh-add /root/.ssh/id_rsa\n[Install]\nWantedBy=default.target\n",
+                "mode": "000400",
+                "owner": "root",
+                "group": "root"
+              },
               "/home/ubuntu/docker-compose.yml": {
                 "content": {
                   "Fn::Join": [
@@ -381,7 +387,7 @@
                       {
                         "Ref": "DockerVersion"
                       },
-                      "\n    - BUILDKITE_AGENT_NAME=elastic-%hostname-%n\n    - DOCKER_STORAGE_DRIVER=aufs\n  volumes:\n    - /home/ubuntu/buildkite/hooks:/buildkite/hooks\n    - /root/.ssh:/root/.ssh\n  restart: always\n"
+                      "\n    - BUILDKITE_AGENT_NAME=elastic-%hostname-%n\n    - DOCKER_STORAGE_DRIVER=aufs\n    - SSH_AUTH_SOCK=/ssh-agent\n  volumes:\n    - /home/ubuntu/buildkite/hooks:/buildkite/hooks\n    - /ssh-agent:/ssh-agent\n  restart: always\n"
                     ]
                   ]
                 },
@@ -418,7 +424,10 @@
               }
             },
             "commands": {
-              "01-install-buildkite": {
+              "01-enable-ssh-agent-systemd": {
+                "command": "systemctl daemon-reload\nsystemctl enable ssh-agent\nsystemctl start ssh-agent\n"
+              },
+              "02-install-buildkite": {
                 "command": {
                   "Fn::Join": [
                     "",
@@ -432,7 +441,7 @@
                   ]
                 }
               },
-              "02-fetch-authorized-users": {
+              "03-fetch-authorized-users": {
                 "command": "/etc/cron.hourly/authorized_keys"
               }
             }

--- a/buildkite-elastic.yml
+++ b/buildkite-elastic.yml
@@ -210,6 +210,21 @@ Resources:
               mode: '000700'
               owner: ubuntu
               group: ubuntu
+            "/lib/systemd/system/ssh-agent.service":
+              content: |
+                [Unit]
+                Description=ssh-agent
+                Before=docker.service
+                [Service]
+                Type=forking
+                Environment=SSH_AUTH_SOCK=/ssh-agent
+                ExecStart=/usr/bin/ssh-agent -a \$SSH_AUTH_SOCK
+                ExecStartPost=/usr/bin/ssh-add /root/.ssh/id_rsa
+                [Install]
+                WantedBy=default.target
+              mode: '000400'
+              owner: root
+              group: root
             "/home/ubuntu/docker-compose.yml":
               content: |
                 buildkite:
@@ -220,9 +235,10 @@ Resources:
                     - BUILDKITE_AGENT_META_DATA=queue=$(BuildkiteQueue),docker=$(DockerVersion)
                     - BUILDKITE_AGENT_NAME=elastic-%hostname-%n
                     - DOCKER_STORAGE_DRIVER=aufs
+                    - SSH_AUTH_SOCK=/ssh-agent
                   volumes:
                     - /home/ubuntu/buildkite/hooks:/buildkite/hooks
-                    - /root/.ssh:/root/.ssh
+                    - /ssh-agent:/ssh-agent
                   restart: always
               mode: '000600'
               owner: ubuntu
@@ -246,12 +262,17 @@ Resources:
               group: root
 
           commands:
-            01-install-buildkite:
+            01-enable-ssh-agent-systemd:
+              command: |
+                systemctl daemon-reload
+                systemctl enable ssh-agent
+                systemctl start ssh-agent
+            02-install-buildkite:
               command: |
                 docker-compose -f /home/ubuntu/docker-compose.yml pull
                 docker-compose -f /home/ubuntu/docker-compose.yml up -d buildkite
                 docker-compose -f /home/ubuntu/docker-compose.yml scale buildkite=$(AgentsPerHost)
-            02-fetch-authorized-users:
+            03-fetch-authorized-users:
               command: /etc/cron.hourly/authorized_keys
 
 


### PR DESCRIPTION
This adds back the previously removed ssh-agent instance, which is passed into the docker agent containers via `SSH_AUTH_SOCKET=/ssh-agent`. 