### PR TITLE
`bundle exec` ensures cfoo is found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: build/aws-stack.json
 
 build/aws-stack.json: templates/buildkite-elastic.yml templates/mappings.yml templates/autoscale.yml templates/vpc.yml
 	-mkdir -p build/
-	cfoo $^ > $@
+	bundle exec cfoo $^ > $@
 
 setup:
 	which bundle || gem install bundler --no-ri --no-rdoc


### PR DESCRIPTION
Instructions in README.md failed:
```
$ make setup clean build
which bundle || gem install bundler --no-ri --no-rdoc
/Users/mbailey/.gem/ruby/2.2.0/bin/bundle
bundle install --path vendor/bundle
Fetching gem metadata from https://rubygems.org/..
Installing blankslate 2.1.2.4
Installing json 1.8.2
Installing parslet 1.5.0
Installing cfoo 0.0.5
Using bundler 1.7.12
Your bundle is complete!
It was installed into ./vendor/bundle
rm build/*
rm: build/*: No such file or directory
make: [clean] Error 1 (ignored)
mkdir -p build/
cfoo templates/buildkite-elastic.yml templates/mappings.yml templates/autoscale.yml templates/vpc.yml > build/aws-stack.json
/bin/sh: cfoo: command not found
make: *** [build/aws-stack.json] Error 127
```