### PR TITLE
Add generic support for encrypted secrets stored on s3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,3 +18,10 @@ steps:
     branches: master
     agents:
       queue: aws-stack
+
+  - wait
+
+  - command: ci/cleanup.sh
+    name: "Cleanup"
+    agents:
+      queue: aws-stack

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ aws cloudformation create-stack \
 | BuildkiteOrgSlug             | Your Buildkite Organization slug (e.g 99designs)                     |                 |
 | BuildkiteAgentToken          | Your Buildkite Agent Token                                           |                 |
 | BuildkiteQueue               | The Buildkite queue to give the agents                               | elastic         |
-| ProvisionBucket              | An S3 bucket and prefix that contains your credentials/keys          |                 |
+| SecretsBucket                | An S3 bucket (and optional prefix) that contains secrets             |                 |
 | InstanceType                 | The EC2 instance size to launch                                      | t2.nano         |
 | MinSize                      | The minimum number of instances to launch                            | 1               |
 | MaxSize                      | The maximum number of instances to launch                            | 1               |
@@ -38,19 +38,28 @@ Check out [`buildkite-elastic.yml`](templates/buildkite-elastic.yml) for more de
 
 Set your [Agent Query Rules](https://buildkite.com/docs/agent/agent-meta-data) to `queue=elastic`, or to whatever `BuildkiteQueue` you provided to your stack.
 
-## Credentials
+## Secrets
 
-Your stack has access to the `ProvisionBucket` parameter you passed in, you can use this to get a GitHub SSH key to the build and soon will be able to use it to get generic credentials there too.
+Your stack has access to the `SecretsBucket` parameter you passed in. This should be used in combination with strong encryption to ensure that your CI secrets (such as Github credentials) are reasonably secure. See the Security section for more details.
 
-For now, upload your GitHub key to the bucket, which should be private by default.
+You provide a key via an environment var in your Buildkite config called `BUILDKITE_SECRETS_KEY` which will be used to decrypt all the files found in the secrets bucket.
 
-For Docker Hub credentials, you can use `DOCKER_HUB_USER`, `DOCKER_HUB_PASSWORD` and `DOCKER_HUB_EMAIL`.
+Two files are specifically looked for, `id_rsa_github`, for checking out your git code and optionally `env`, which contains environment variables to expose to the job command.
+
+### Uploading your Secrets
 
 ```bash
-aws s3 cp --acl private my_id_rsa_key "s3://my-provision-bucket/id_rsa_github"
+PASSPHRASE=$(date +%s%N | sha256sum | base64 | head -c 32 ; echo) # generates a 32 character randomish password, use gdate for MacOS
+aws s3 cp --acl private --sse-c --sse-c-key "$PASSPHRASE" my_id_rsa_key "s3://my-provision-bucket/myproject/id_rsa_github"
 ```
 
-Then in your Buildkite environment variables, set `SSH_KEY_URL` to `s3://my-provision-bucket/id_rsa_github`.
+For Docker Hub credentials, you can use `DOCKER_HUB_USER`, `DOCKER_HUB_PASSWORD` and `DOCKER_HUB_EMAIL` in your `env` file.
+
+## Security
+
+This repository hasn't been reviewed by security researchers, so exercise caution and careful thought with what credentials you make available to your builds. At present anyone with access to your CI machines or commit access to your codebase (including third-party pull-requests) will theoretically have access to your encrypted secrets. Anyone with access to your Buildkite Project Configuration will be able to retrieve the encryption key used to decrypt these. In combination, the attacker would have access to your decrypted secrets.
+
+Presently the EC2 Metadata instance is available via HTTP request from builds, which means that builds have the same IAM access as the basic build host does.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Two files are specifically looked for, `id_rsa_github`, for checking out your gi
 ### Uploading your Secrets
 
 ```bash
-PASSPHRASE=$(date +%s%N | sha256sum | base64 | head -c 32 ; echo) # generates a 32 character randomish password, use gdate for MacOS
+PASSPHRASE=$(head -c 24  /dev/urandom | base64)
 aws s3 cp --acl private --sse-c --sse-c-key "$PASSPHRASE" my_id_rsa_key "s3://my-provision-bucket/myproject/id_rsa_github"
 ```
 

--- a/ci/cleanup.sh
+++ b/ci/cleanup.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -eu
-set -x
 
 stack_name=$(buildkite-agent meta-data get stack_name)
 bk_pipeline_slug=$(buildkite-agent meta-data get bk_pipeline_slug)
@@ -9,4 +8,5 @@ echo "--- Deleting stack $stack_name"
 aws cloudformation delete-stack --stack-name "$stack_name"
 
 echo "--- Deleting pipeline $bk_pipeline_slug"
-curl --show-error --silent -f -X DELETE "https://api.buildkite.com/v2/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/pipelines/$bk_pipeline_slug"
+curl --show-error --silent -f -X DELETE -H "Authorization: Bearer $BUILDKITE_AWS_STACK_API_TOKEN" \
+  "https://api.buildkite.com/v2/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/pipelines/$bk_pipeline_slug"

--- a/ci/cleanup.sh
+++ b/ci/cleanup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eu
+set -x
 
 stack_name=$(buildkite-agent meta-data get stack_name)
 bk_pipeline_slug=$(buildkite-agent meta-data get bk_pipeline_slug)

--- a/ci/cleanup.sh
+++ b/ci/cleanup.sh
@@ -2,11 +2,6 @@
 set -eu
 
 stack_name=$(buildkite-agent meta-data get stack_name)
-bk_pipeline_slug=$(buildkite-agent meta-data get bk_pipeline_slug)
 
 echo "--- Deleting stack $stack_name"
 aws cloudformation delete-stack --stack-name "$stack_name"
-
-echo "--- Deleting pipeline $bk_pipeline_slug"
-curl --show-error --silent -f -X DELETE -H "Authorization: Bearer $BUILDKITE_AWS_STACK_API_TOKEN" \
-  "https://api.buildkite.com/v2/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/pipelines/$bk_pipeline_slug"

--- a/ci/cleanup.sh
+++ b/ci/cleanup.sh
@@ -2,6 +2,10 @@
 set -eu
 
 stack_name=$(buildkite-agent meta-data get stack_name)
+bk_pipeline_slug=$(buildkite-agent meta-data get bk_pipeline_slug)
 
 echo "--- Deleting stack $stack_name"
 aws cloudformation delete-stack --stack-name "$stack_name"
+
+echo "--- Deleting pipeline $bk_pipeline_slug"
+curl --silent -f -X DELETE "https://api.buildkite.com/v2/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/pipelines/$bk_pipeline_slug"

--- a/ci/cleanup.sh
+++ b/ci/cleanup.sh
@@ -8,4 +8,4 @@ echo "--- Deleting stack $stack_name"
 aws cloudformation delete-stack --stack-name "$stack_name"
 
 echo "--- Deleting pipeline $bk_pipeline_slug"
-curl --silent -f -X DELETE "https://api.buildkite.com/v2/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/pipelines/$bk_pipeline_slug"
+curl --show-error --silent -f -X DELETE "https://api.buildkite.com/v2/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/pipelines/$bk_pipeline_slug"

--- a/ci/cleanup.sh
+++ b/ci/cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+
+stack_name=$(buildkite-agent meta-data get stack_name)
+
+echo "--- Deleting stack $stack_name"
+aws cloudformation delete-stack --stack-name "$stack_name"

--- a/ci/steps.sh
+++ b/ci/steps.sh
@@ -20,7 +20,7 @@ steps:
   - wait
 
   - command: sleep 5
-    name: "Running a command on :buildkite: agent"
+    name: "Run a command on :buildkite: agent"
     timeout_in_minutes: 5
     env:
       BUILDKITE_SECRETS_KEY: $BUILDKITE_SECRETS_KEY

--- a/ci/steps.sh
+++ b/ci/steps.sh
@@ -13,7 +13,7 @@ steps:
   - wait
 
   - command: ci/test.sh
-    name: "Test :cloudformation: stack"
+    name: "Launch :cloudformation: stack"
     agents:
       queue: aws-stack
 
@@ -22,6 +22,8 @@ steps:
   - command: sleep 5
     name: "Running a command on :buildkite: agent"
     timeout_in_minutes: 5
+    env:
+      BUILDKITE_SECRETS_KEY: $BUILDKITE_SECRETS_KEY
     agents:
       stack: $stack_name
       queue: $queue_name

--- a/ci/steps.sh
+++ b/ci/steps.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+export stack_name="buildkite-aws-stack-test-$$"
+export queue_name="testqueue-$$"
+
+cat << EOF
 steps:
   - command: ci/packer.sh
     name: "Build packer image"
@@ -13,6 +19,15 @@ steps:
 
   - wait
 
+  - command: sleep 5
+    name: "Running a command on :buildkite: agent"
+    timeout_in_minutes: 5
+    agents:
+      stack: $stack_name
+      queue: $queue_name
+
+  - wait
+
   - command: ci/publish.sh
     name: "Publishing :cloudformation: stack"
     branches: master
@@ -25,3 +40,8 @@ steps:
     name: "Cleanup"
     agents:
       queue: aws-stack
+EOF
+
+buildkite-agent meta-data set stack_name "$stack_name"
+buildkite-agent meta-data set queue_name "$queue_name"
+

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -39,8 +39,8 @@ query_bk_agent_api() {
 
 create_bk_pipeline() {
   curl --silent -f -X POST -H "Authorization: Bearer $BUILDKITE_AWS_STACK_API_TOKEN" \
-  "https://api.buildkite.com/v2/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/pipelines" \
-  -d @-
+    "https://api.buildkite.com/v2/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/pipelines" \
+    -d @-
 }
 
 vpc_id=$(aws ec2 describe-vpcs --filters "Name=isDefault,Values=true" --query "Vpcs[0].VpcId" --output text)
@@ -126,9 +126,8 @@ fi
 
 echo
 echo "--- Creating buildkite pipeline"
-set -x
 
-read -r -d '' create_bk_pipeline_body << EOF
+create_bk_pipeline_body=$(cat << EOF
 {
   "name": "${stack_name}",
   "repository": "git@github.com:buildkite/buildkite-aws-stack.git",
@@ -142,6 +141,7 @@ read -r -d '' create_bk_pipeline_body << EOF
   ]
 }
 EOF
+)
 
 if ! pipeline_json=$(create_bk_pipeline <<< "$create_bk_pipeline_body") ; then
   echo -e "\033[33;31mFailed to create buildkite pipeline\033[0m"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -73,7 +73,7 @@ cat << EOF > config.json
     "ParameterValue": "t2.micro"
   },
   {
-    "ParameterKey": "ProvisionBucket",
+    "ParameterKey": "SecretsBucket",
     "ParameterValue": "${BUILDKITE_AWS_STACK_BUCKET}"
   },
   {

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -207,6 +207,8 @@ fi
 
 echo "$build_json"
 
+set -x
+
 echo "--- Waiting for build to complete"
 bk_build_follow "$pipeline_slug" "1"
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -115,7 +115,6 @@ echo
 echo "--- Waiting for agents to start"
 sleep 10
 
-echo
 echo "--- Checking agent has registered correctly"
 if ! query_bk_agent_api "?name=${stack_name}-1" | grep -C 20 --color=always '"connection_state": "connected"' ; then
   echo -e "\033[33;31mAgent failed to connect to buildkite\033[0m"
@@ -124,9 +123,7 @@ else
   echo -e "\033[33;32mAgent connected successfully\033[0m"
 fi
 
-echo
 echo "--- Creating buildkite pipeline"
-
 create_bk_pipeline_body=$(cat << EOF
 {
   "name": "${stack_name}",
@@ -134,8 +131,8 @@ create_bk_pipeline_body=$(cat << EOF
   "steps": [
     {
       "type": "script",
-      "name": "Test :rocket:",
-      "command": "script/release.sh",
+      "name": "Sleep",
+      "command": "sleep 10",
       "agent_query_rules": ["stack_name=${stack_name}"]
     }
   ]

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -38,7 +38,7 @@ query_bk_agent_api() {
 }
 
 create_bk_pipeline() {
-  curl -X POST -H "Authorization: Bearer $BUILDKITE_AWS_STACK_API_TOKEN" \
+  curl --silent -f -X POST -H "Authorization: Bearer $BUILDKITE_AWS_STACK_API_TOKEN" \
   "https://api.buildkite.com/v2/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/pipelines" \
   -d @-
 }
@@ -124,21 +124,21 @@ else
   echo -e "\033[33;32mAgent connected successfully\033[0m"
 fi
 
-
-cat << REQUEST_BODY |
+echo
+echo "--- Creating buildkite pipeline"
+cat << REQUEST_BODY | create_bk_pipeline
 {
-  "name": "Test Pipeline for $stack_name",
+  "name": "Test Pipeline for ${STACK_NAME}",
   "repository": "git@github.com:buildkite/buildkite-aws-stack.git",
   "steps": [
     {
       "type": "script",
       "name": "Test :rocket:",
       "command": "script/release.sh",
-      "agent_query_rules": ["stack_name=$stack_name"]
+      "agent_query_rules": ["stack_name=${STACK_NAME}"]
     }
   ]
 }
 REQUEST_BODY
-create_bk_pipeline
 
 buildkite-agent meta-data set stack_name "$STACK_NAME"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -153,5 +153,7 @@ if ! pipeline_slug=$(awk '/slug/ {print $2}' <<< "$pipeline_json" | cut -d\" -f2
   exit 1
 fi
 
+echo "$pipeline_json"
+
 buildkite-agent meta-data set bk_pipeline_slug "$pipeline_slug"
 buildkite-agent meta-data set stack_name "$stack_name"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -207,6 +207,8 @@ fi
 echo "$build_json"
 
 echo "--- Waiting for build to complete"
+
+set -x
 bk_build_follow "$pipeline_slug" "1"
 
 buildkite-agent meta-data set bk_pipeline_slug "$pipeline_slug"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -33,12 +33,12 @@ stack_follow() {
 }
 
 query_bk_agent_api() {
-  curl --silent -f -H "Authorization: Bearer $BUILDKITE_AWS_STACK_API_TOKEN" \
+  curl --show-error --silent -f -H "Authorization: Bearer $BUILDKITE_AWS_STACK_API_TOKEN" \
     "https://api.buildkite.com/v1/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/agents$*"
 }
 
 create_bk_pipeline() {
-  curl --silent -f -X POST -H "Authorization: Bearer $BUILDKITE_AWS_STACK_API_TOKEN" \
+  curl --show-error --silent -f -X POST -H "Authorization: Bearer $BUILDKITE_AWS_STACK_API_TOKEN" \
     "https://api.buildkite.com/v2/organizations/$BUILDKITE_AWS_STACK_ORG_SLUG/pipelines" \
     -d @-
 }
@@ -126,7 +126,6 @@ fi
 
 echo
 echo "--- Creating buildkite pipeline"
-set -x
 
 create_bk_pipeline_body=$(cat << EOF
 {
@@ -145,7 +144,6 @@ EOF
 )
 
 if ! pipeline_json=$(create_bk_pipeline <<< "$create_bk_pipeline_body") ; then
-  echo $pipeline_json
   echo -e "\033[33;31mFailed to create buildkite pipeline\033[0m"
   exit 1
 fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -124,6 +124,10 @@ else
   echo -e "\033[33;32mAgent connected successfully\033[0m"
 fi
 
+echo
+echo "--- Creating buildkite pipeline"
+set -x
+
 read -r -d '' create_bk_pipeline_body << EOF
 {
   "name": "${stack_name}",
@@ -139,8 +143,6 @@ read -r -d '' create_bk_pipeline_body << EOF
 }
 EOF
 
-echo
-echo "--- Creating buildkite pipeline"
 if ! pipeline_json=$(create_bk_pipeline <<< "$create_bk_pipeline_body") ; then
   echo -e "\033[33;31mFailed to create buildkite pipeline\033[0m"
   exit 1

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -126,6 +126,7 @@ fi
 
 echo
 echo "--- Creating buildkite pipeline"
+set -x
 
 create_bk_pipeline_body=$(cat << EOF
 {
@@ -144,6 +145,7 @@ EOF
 )
 
 if ! pipeline_json=$(create_bk_pipeline <<< "$create_bk_pipeline_body") ; then
+  echo $pipeline_json
   echo -e "\033[33;31mFailed to create buildkite pipeline\033[0m"
   exit 1
 fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -148,7 +148,10 @@ if ! pipeline_json=$(create_bk_pipeline <<< "$create_bk_pipeline_body") ; then
   exit 1
 fi
 
-pipeline_slug=$(awk '/slug/ {print $2}' <<< "$pipeline_json" | sed 's/"//g')
+if ! pipeline_slug=$(awk '/slug/ {print $2}' <<< "$pipeline_json" | cut -d\" -f2) ; then
+  echo -e "\033[33;31mFailed to find a pipeline slug\033[0m"
+  exit 1
+fi
 
 buildkite-agent meta-data set bk_pipeline_slug "$pipeline_slug"
 buildkite-agent meta-data set stack_name "$stack_name"

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -14,7 +14,7 @@ echo '+++ :house_with_garden: Setting up the environment'
 
 source ~/cfn-env
 
-if [[ -n "$BUILDKITE_SECRETS_BUCKET" ]] && [[ -z "$BUILDKITE_SECRETS_KEY" ]] ; then
+if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] && [[ -z "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
   echo "A SecretsBucket was provided, but no encryption key via BUILDKITE_SECRETS_KEY."
   exit 1
 fi

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -4,7 +4,7 @@ set -eu
 download_github_key() {
   local key_url="s3://${BUILDKITE_SECRETS_BUCKET}/$1"
   echo "~~~ Downloading encrypted github ssh key from $key_url" >&2
-  if ! env -i aws s3 cp --sse-c --sse-c-key "$BUILDKITE_SECRETS_KEY" "$key_url" - l ; then
+  if ! env -i aws s3 cp --sse-c AES256 --sse-c-key "$BUILDKITE_SECRETS_KEY" "$key_url" /dev/stdout ; then
     echo "Failed to download and decrypt $key_url"  >&2
     return 1
   fi

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -4,7 +4,7 @@ set -eu
 download_github_key() {
   local key_url="s3://${BUILDKITE_SECRETS_BUCKET}/$1"
   echo "~~~ Downloading encrypted github ssh key from $key_url" >&2
-  if ! env -i aws s3 cp --sse-c AES256 --sse-c-key "$BUILDKITE_SECRETS_KEY" "$key_url" /dev/stdout ; then
+  if ! env -i aws s3 cp --sse-c AES256 --sse-c-key "$BUILDKITE_SECRETS_KEY" --quiet "$key_url" /dev/stdout ; then
     echo "Failed to download and decrypt $key_url"  >&2
     return 1
   fi

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -10,13 +10,14 @@ if [[ -n "$BUILDKITE_SECRETS_BUCKET" ]] && [[ -z "$BUILDKITE_SECRETS_KEY" ]] ; t
   exit 1
 fi
 
-SSH_KEY_URL="${SSH_KEY_URL:-s3://${BUILDKITE_SECRETS_BUCKET}/id_rsa_github}"
+SSH_KEY_NAME="${SSH_KEY_NAME:-id_rsa_github}"
+SSH_KEY_URL="s3://${BUILDKITE_SECRETS_BUCKET}/$SSH_KEY_NAME"
 
 if ! github_ssh_key=$(env -i aws s3 cp --sse-c --sse-c-key "$BUILDKITE_SECRETS_KEY" "$SSH_KEY_URL") ; then
   echo "Failed to download and decrypt $SSH_KEY_URL"
 fi
 
-eval `ssh-agent -s`
+eval "$(ssh-agent -s)"
 
 # startup an ssh-agent with the ssh-key
 if [[ -n "${SSH_KEY_URL:-}" ]] ; then

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -eu
 
+download_github_key() {
+  local key_url="s3://${BUILDKITE_SECRETS_BUCKET}/$1"
+  echo "~~~ Downloading encrypted github ssh key from $key_url" >&2
+  if ! env -i aws s3 cp --sse-c --sse-c-key "$BUILDKITE_SECRETS_KEY" "$key_url" - l ; then
+    echo "Failed to download and decrypt $key_url"  >&2
+    return 1
+  fi
+}
+
 echo '+++ :house_with_garden: Setting up the environment'
 
 source ~/cfn-env
@@ -11,19 +20,10 @@ if [[ -n "$BUILDKITE_SECRETS_BUCKET" ]] && [[ -z "$BUILDKITE_SECRETS_KEY" ]] ; t
 fi
 
 SSH_KEY_NAME="${SSH_KEY_NAME:-id_rsa_github}"
-SSH_KEY_URL="s3://${BUILDKITE_SECRETS_BUCKET}/$SSH_KEY_NAME"
-
-if ! github_ssh_key=$(env -i aws s3 cp --sse-c --sse-c-key "$BUILDKITE_SECRETS_KEY" "$SSH_KEY_URL") ; then
-  echo "Failed to download and decrypt $SSH_KEY_URL"
-fi
-
-eval "$(ssh-agent -s)"
 
 # startup an ssh-agent with the ssh-key
-if [[ -n "${SSH_KEY_URL:-}" ]] ; then
-  echo "~~~ Downloading github ssh key from $SSH_KEY_URL"
-  ssh-add <(echo $github_ssh_key)
-fi
+eval "$(ssh-agent -s)"
+ssh-add <(download_github_key "$SSH_KEY_NAME")
 
 if [[ $(docker ps -q | wc -l) -gt 0 ]] ; then
   echo "~~~ Stopping existing :docker: containers"

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -3,30 +3,25 @@ set -eu
 
 echo '+++ :house_with_garden: Setting up the environment'
 
-[[ -f ~/.docker/config.json ]] && rm ~/.docker/config.json
-[[ -f ~/.dockercfg ]] && rm ~/.dockercfg
+source ~/cfn-env
 
- # handle docker hub authentication
-if [[ -n "${DOCKER_HUB_AUTH:-}" ]] ; then
-  echo "DOCKER_HUB_AUTH is no longer supported, use DOCKER_HUB_USER, DOCKER_HUB_PASSWORD and DOCKER_HUB_EMAIL."
+if [[ -n "$BUILDKITE_SECRETS_BUCKET" ]] && [[ -z "$BUILDKITE_SECRETS_KEY" ]] ; then
+  echo "A SecretsBucket was provided, but no encryption key via BUILDKITE_SECRETS_KEY."
   exit 1
-elif [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" && -n "${DOCKER_HUB_EMAIL:-}" ]] ; then
-  echo "~~~ Authenticating with :docker: as ${DOCKER_HUB_USER}"
-  docker login --username="${DOCKER_HUB_USER}" --password="${DOCKER_HUB_PASSWORD}" --email="${DOCKER_HUB_EMAIL}"
-elif [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]] ; then
-  echo "Missing DOCKER_HUB_EMAIL."
-  exit 1
+fi
+
+SSH_KEY_URL="${SSH_KEY_URL:-s3://${BUILDKITE_SECRETS_BUCKET}/id_rsa_github}"
+
+if ! github_ssh_key=$(env -i aws s3 cp --sse-c --sse-c-key "$BUILDKITE_SECRETS_KEY" "$SSH_KEY_URL") ; then
+  echo "Failed to download and decrypt $SSH_KEY_URL"
 fi
 
 eval `ssh-agent -s`
 
 # startup an ssh-agent with the ssh-key
 if [[ -n "${SSH_KEY_URL:-}" ]] ; then
-  echo "~~~ Downloading :github: ssh key"
-  TMPKEY=$(mktemp /tmp/buildkite.XXXXXXXXXX)
-  trap "rm $TMPKEY" exit
-  env -i aws s3 cp ${SSH_KEY_URL:-} $TMPKEY
-  ssh-add $TMPKEY
+  echo "~~~ Downloading github ssh key from $SSH_KEY_URL"
+  ssh-add <(echo $github_ssh_key)
 fi
 
 if [[ $(docker ps -q | wc -l) -gt 0 ]] ; then

--- a/packer/conf/hooks/pre-command
+++ b/packer/conf/hooks/pre-command
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eu
+
+echo '+++ :docker: Authenticating to Docker Hub'
+
+[[ -f ~/.docker/config.json ]] && rm ~/.docker/config.json
+[[ -f ~/.dockercfg ]] && rm ~/.dockercfg
+
+ # handle docker hub authentication
+if [[ -n "${DOCKER_HUB_AUTH:-}" ]] ; then
+  echo "DOCKER_HUB_AUTH is no longer supported, use DOCKER_HUB_USER, DOCKER_HUB_PASSWORD and DOCKER_HUB_EMAIL."
+  exit 1
+elif [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" && -n "${DOCKER_HUB_EMAIL:-}" ]] ; then
+  echo "~~~ Authenticating with docker hub as ${DOCKER_HUB_USER}"
+  docker login --username="${DOCKER_HUB_USER}" --password="${DOCKER_HUB_PASSWORD}" --email="${DOCKER_HUB_EMAIL}"
+elif [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]] ; then
+  echo "Missing DOCKER_HUB_EMAIL."
+  exit 1
+fi

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -184,11 +184,13 @@ Resources:
       AWS::CloudFormation::Init:
         config:
           commands:
-            01-download-github-key:
-              test: test -n "$(SecretsBucket)"
+            01-write-buildkite-env:
               command: |
-                aws s3 cp s3://$(SecretsBucket)/id_rsa_buildkite /root/.ssh/id_rsa
-                chmod 0600 /root/.ssh/id_rsa
+                cat << EOF > /var/lib/buildkite-agent/cfn-env
+                BUILDKITE_STACK_NAME=$(AWS::StackName)
+                BUILDKITE_SECRETS_BUCKET=$(SecretsBucket)
+                EOF
+                chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
             02-install-buildkite:
               command: |
                 sed -i -r 's/^(name)=.*/\1="$(AWS::StackName)-%n"/' /etc/buildkite-agent/buildkite-agent.cfg

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -20,7 +20,7 @@ Parameters:
     Type: String
     Default: elastic
 
-  ProvisionBucket:
+  SecretsBucket:
     Description: An s3 bucket containing provisioning files
     Type: String
     Default: ""
@@ -98,8 +98,8 @@ Conditions:
     UseSpecifiedAvailabilityZones:
       !Not [ !Equals [ !Join [ "", $(AvailabilityZones) ], "" ]  ]
 
-    UseProvisionBucket:
-      !Not [ !Equals [ $(ProvisionBucket), "" ] ]
+    UseSecretsBucket:
+      !Not [ !Equals [ $(SecretsBucket), "" ] ]
 
     UseDefaultAMI:
       !Equals [ $(ImageId), "" ]
@@ -138,11 +138,11 @@ Resources:
       Roles:
         - $(IAMRole)
 
-  ProvisionBucketPolicies:
+  SecretsBucketPolicies:
     Type: AWS::IAM::Policy
-    Condition: UseProvisionBucket
+    Condition: UseSecretsBucket
     Properties:
-      PolicyName: ProvisionBucketPolicy
+      PolicyName: SecretsBucketPolicy
       PolicyDocument:
         Statement:
           - Effect: Allow
@@ -152,7 +152,7 @@ Resources:
               - s3:ListBucket
               - s3:ListBucketVersions
             Resource:
-              - "arn:aws:s3:::$(ProvisionBucket)/*"
+              - "arn:aws:s3:::$(SecretsBucket)/*"
       Roles:
         - $(IAMRole)
 
@@ -185,9 +185,9 @@ Resources:
         config:
           commands:
             01-download-github-key:
-              test: test -n "$(ProvisionBucket)"
+              test: test -n "$(SecretsBucket)"
               command: |
-                aws s3 cp s3://$(ProvisionBucket)/id_rsa_buildkite /root/.ssh/id_rsa
+                aws s3 cp s3://$(SecretsBucket)/id_rsa_buildkite /root/.ssh/id_rsa
                 chmod 0600 /root/.ssh/id_rsa
             02-install-buildkite:
               command: |


### PR DESCRIPTION
This change will require that secrets like the github key be encrypted at rest and decrypted per job with a project specific secret key.

See specifically the changes to the README.md.