### PR TITLE
Support encrypted env file in secrets

### DIFF
--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -2,11 +2,11 @@
 set -eu
 
 s3_exists() {
-  env -i aws s3 ls "${BUILDKITE_SECRETS_BUCKET}/$1" "$2" &>/dev/null
+  env -i aws s3 ls "s3://${BUILDKITE_SECRETS_BUCKET}/$1" "$2" &>/dev/null
 }
 
 s3_download() {
-  env -i aws s3 cp --quiet --sse-c AES256 --sse-c-key "${BUILDKITE_SECRETS_KEY}" "${BUILDKITE_SECRETS_BUCKET}/$1" /dev/stdout
+  env -i aws s3 cp --quiet --sse-c AES256 --sse-c-key "${BUILDKITE_SECRETS_KEY}" "s3://${BUILDKITE_SECRETS_BUCKET}/$1" /dev/stdout
 }
 
 echo '+++ :house_with_garden: Setting up the environment'

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -2,7 +2,7 @@
 set -eu
 
 s3_exists() {
-  env -i aws s3 ls "s3://${BUILDKITE_SECRETS_BUCKET}/$1" "$2" &>/dev/null
+  env -i aws s3 ls "s3://${BUILDKITE_SECRETS_BUCKET}/$1" &>/dev/null
 }
 
 s3_download() {

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eu
 
+s3_download() {
+  env -i aws s3 cp --sse-c AES256 --sse-c-key "${BUILDKITE_SECRETS_KEY}" "${BUILDKITE_SECRETS_BUCKET}/$1" $2
+}
+
 echo '+++ :house_with_garden: Setting up the environment'
 
 source ~/cfn-env
@@ -15,14 +19,15 @@ eval "$(ssh-agent -s)"
 if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   [[ -d ~/secrets ]] || mkdir -p ~/secrets
 
-  echo "+++ Downloading secrets from $BUILDKITE_SECRETS_BUCKET"
-  env -i aws s3 sync --delete --sse-c AES256 --sse-c-key "${BUILDKITE_SECRETS_KEY}" "s3://${BUILDKITE_SECRETS_BUCKET}" ~/secrets/
+  echo "Downloading ssh key from $BUILDKITE_SECRETS_BUCKET"
+  if s3_download "${SSH_KEY_NAME:-id_rsa_github}" ~/secrets/id_rsa_github ; then
+    ssh-add ~/secrets/id_rsa_github
+  fi
 
-  ssh_key_file="$HOME/secrets/${SSH_KEY_NAME:-id_rsa_github}"
-  [[ -f $ssh_key_file ]] && ssh-add "$ssh_key_file"
-
-  env_file="$HOME/secrets/env"
-  [[ -f $env_file ]] && eval "$(cat "$env_file")"
+  echo "Downloading env from $BUILDKITE_SECRETS_BUCKET"
+  if s3_download "env" ~/secrets/env ; then
+    source ~/secrets/env
+  fi
 fi
 
 if [[ $(docker ps -q | wc -l) -gt 0 ]] ; then

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -1,15 +1,6 @@
 #!/bin/bash
 set -eu
 
-download_github_key() {
-  local key_url="s3://${BUILDKITE_SECRETS_BUCKET}/$1"
-  echo "~~~ Downloading encrypted github ssh key from $key_url" >&2
-  if ! env -i aws s3 cp --sse-c AES256 --sse-c-key "$BUILDKITE_SECRETS_KEY" --quiet "$key_url" /dev/stdout ; then
-    echo "Failed to download and decrypt $key_url"  >&2
-    return 1
-  fi
-}
-
 echo '+++ :house_with_garden: Setting up the environment'
 
 source ~/cfn-env
@@ -19,11 +10,20 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] && [[ -z "${BUILDKITE_SECRETS_KEY:-}
   exit 1
 fi
 
-SSH_KEY_NAME="${SSH_KEY_NAME:-id_rsa_github}"
-
-# startup an ssh-agent with the ssh-key
 eval "$(ssh-agent -s)"
-ssh-add <(download_github_key "$SSH_KEY_NAME")
+
+if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
+  [[ -d ~/secrets ]] || mkdir -p ~/secrets
+
+  echo "+++ Downloading secrets from $BUILDKITE_SECRETS_BUCKET"
+  env -i aws s3 sync --delete --sse-c AES256 --sse-c-key "${BUILDKITE_SECRETS_KEY}" "s3://${BUILDKITE_SECRETS_BUCKET}" ~/secrets/
+
+  ssh_key_file="$HOME/secrets/${SSH_KEY_NAME:-id_rsa_github}"
+  [[ -f $ssh_key_file ]] && ssh-add "$ssh_key_file"
+
+  env_file="$HOME/secrets/env"
+  [[ -f $env_file ]] && eval "$(cat "$env_file")"
+fi
 
 if [[ $(docker ps -q | wc -l) -gt 0 ]] ; then
   echo "~~~ Stopping existing :docker: containers"

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -eu
 
+s3_exists() {
+  env -i aws s3 ls "${BUILDKITE_SECRETS_BUCKET}/$1" "$2" &>/dev/null
+}
+
 s3_download() {
-  env -i aws s3 cp --sse-c AES256 --sse-c-key "${BUILDKITE_SECRETS_KEY}" "${BUILDKITE_SECRETS_BUCKET}/$1" $2
+  env -i aws s3 cp --quiet --sse-c AES256 --sse-c-key "${BUILDKITE_SECRETS_KEY}" "${BUILDKITE_SECRETS_BUCKET}/$1" /dev/stdout
 }
 
 echo '+++ :house_with_garden: Setting up the environment'
@@ -17,16 +21,13 @@ fi
 eval "$(ssh-agent -s)"
 
 if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
-  [[ -d ~/secrets ]] || mkdir -p ~/secrets
 
   echo "Downloading ssh key from $BUILDKITE_SECRETS_BUCKET"
-  if s3_download "${SSH_KEY_NAME:-id_rsa_github}" ~/secrets/id_rsa_github ; then
-    ssh-add ~/secrets/id_rsa_github
-  fi
+  ssh-add <(s3_download "${SSH_KEY_NAME:-id_rsa_github}")
 
-  echo "Downloading env from $BUILDKITE_SECRETS_BUCKET"
-  if s3_download "env" ~/secrets/env ; then
-    source ~/secrets/env
+  if s3_exists "env" ; then
+     echo "Downloading env from $BUILDKITE_SECRETS_BUCKET"
+    eval "$(s3_download env)"
   fi
 fi
 

--- a/packer/conf/hooks/post-command
+++ b/packer/conf/hooks/post-command
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 ssh-agent -k
-[[ -d ~/secrets ]] || rm -rf ~/secrets

--- a/packer/conf/hooks/post-command
+++ b/packer/conf/hooks/post-command
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 ssh-agent -k
+[[ -d ~/secrets ]] || rm -rf ~/secrets

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -157,7 +157,7 @@ Resources:
             Action:
               - s3:ListObjects
             Resource:
-              - "arn:aws:s3:::$(SecretsBucket)"
+              - "arn:aws:s3:::$(SecretsBucket)/"
       Roles:
         - $(IAMRole)
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -152,7 +152,7 @@ Resources:
               - s3:List*
             Resource:
               - "arn:aws:s3:::$(SecretsBucket)/*"
-              - "arn:aws:s3:::$(SecretsBucket)/"
+              - "arn:aws:s3:::$(SecretsBucket)"
       Roles:
         - $(IAMRole)
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -153,6 +153,11 @@ Resources:
               - s3:ListBucketVersions
             Resource:
               - "arn:aws:s3:::$(SecretsBucket)/*"
+          - Effect: Allow
+            Action:
+              - s3:ListObjects
+            Resource:
+              - "arn:aws:s3:::$(SecretsBucket)"
       Roles:
         - $(IAMRole)
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -147,16 +147,11 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - s3:GetObject
-              - s3:GetObjectVersion
-              - s3:ListBucket
-              - s3:ListBucketVersions
+              - s3:Get*
+              - s3:Get
+              - s3:List*
             Resource:
               - "arn:aws:s3:::$(SecretsBucket)/*"
-          - Effect: Allow
-            Action:
-              - s3:ListObjects
-            Resource:
               - "arn:aws:s3:::$(SecretsBucket)/"
       Roles:
         - $(IAMRole)


### PR DESCRIPTION
Currently the README mentions that you can have an encrypted `env` file in your `SecretsBucket` which will be sourced and executed as part of the Buildkite environment hook. 