### PR TITLE
Custom autoscaling based on Buildkite/ScheduledJobsCount

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -18,6 +18,7 @@ Resources:
 
   CPUAlarmHigh:
    Type: AWS::CloudWatch::Alarm
+   Condition: ScaleOnCPU
    Properties:
       AlarmDescription: Scale-up if CPU > 40% for 5 minutes
       MetricName: CPUUtilization
@@ -34,6 +35,7 @@ Resources:
 
   CPUAlarmLow:
    Type: AWS::CloudWatch::Alarm
+   Condition: ScaleOnCPU
    Properties:
       AlarmDescription: Scale-down if CPU < 5% for 5 minutes
       MetricName: CPUUtilization
@@ -51,6 +53,7 @@ Resources:
 
   ScheduledJobsAlarmHigh:
    Type: AWS::CloudWatch::Alarm
+   Condition: ScaleOnScheduledJobs
    Properties:
       AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
       MetricName: ScheduledJobsCount
@@ -67,6 +70,7 @@ Resources:
 
   ScheduledJobsAlarmLow:
    Type: AWS::CloudWatch::Alarm
+   Condition: ScaleOnScheduledJobs
    Properties:
       AlarmDescription: Scale-down if ScheduledJobs == 0 for 1 minute
       MetricName: ScheduledJobsCount
@@ -77,6 +81,6 @@ Resources:
       Threshold: 1
       AlarmActions: [ $(AgentScaleDownPolicy) ]
       Dimensions:
-        - Name: AutoScalingGroupName
-          Value: $(AgentAutoScaleGroup)
+        - Name: Queue
+          Value: $(BuildkiteQueue)
       ComparisonOperator: LessThanThreshold

--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -5,7 +5,7 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
-      Cooldown: 60
+      Cooldown: 10
       ScalingAdjustment: 1
 
   AgentScaleDownPolicy:
@@ -13,19 +13,19 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
-      Cooldown : 60
+      Cooldown : 10
       ScalingAdjustment : -1
 
   CPUAlarmHigh:
    Type: AWS::CloudWatch::Alarm
    Properties:
-      AlarmDescription: Scale-up if CPU > 90% for 10 minutes
+      AlarmDescription: Scale-up if CPU > 40% for 5 minutes
       MetricName: CPUUtilization
       Namespace: AWS/EC2
       Statistic: Average
       Period: 300
       EvaluationPeriods: 2
-      Threshold: 90
+      Threshold: 40
       AlarmActions: [ $(AgentScaleUpPolicy) ]
       Dimensions:
         - Name: AutoScalingGroupName
@@ -35,13 +35,46 @@ Resources:
   CPUAlarmLow:
    Type: AWS::CloudWatch::Alarm
    Properties:
-      AlarmDescription: Scale-down if CPU < 70% for 10 minutes
+      AlarmDescription: Scale-down if CPU < 5% for 5 minutes
       MetricName: CPUUtilization
       Namespace: AWS/EC2
       Statistic: Average
       Period: 300
       EvaluationPeriods: 2
-      Threshold: 70
+      Threshold: 5
+      AlarmActions: [ $(AgentScaleDownPolicy) ]
+      Dimensions:
+        - Name: AutoScalingGroupName
+          Value: $(AgentAutoScaleGroup)
+      ComparisonOperator: LessThanThreshold
+
+
+  ScheduledJobsAlarmHigh:
+   Type: AWS::CloudWatch::Alarm
+   Properties:
+      AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
+      MetricName: ScheduledJobsCount
+      Namespace: Buildkite
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      AlarmActions: [ $(AgentScaleUpPolicy) ]
+      Dimensions:
+        - Name: Queue
+          Value: $(BuildkiteQueue)
+      ComparisonOperator: GreaterThanThreshold
+
+  ScheduledJobsAlarmLow:
+   Type: AWS::CloudWatch::Alarm
+   Properties:
+      AlarmDescription: Scale-down if ScheduledJobs == 0 for 1 minute
+      MetricName: ScheduledJobsCount
+      Namespace: Buildkite
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
       AlarmActions: [ $(AgentScaleDownPolicy) ]
       Dimensions:
         - Name: AutoScalingGroupName

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -85,6 +85,14 @@ Parameters:
     Description: The AMI to use, otherwise uses the mapping built in
     Default: ""
 
+  AutoscaleStrategy:
+    Type: String
+    Description: The strategy to use for autoscaling
+    Default: cpu
+    AllowedValues:
+      - cpu
+      - scheduledjobs
+
 Conditions:
     UseSpotInstances:
       !Not [ !Equals [ $(SpotPrice), 0 ] ]
@@ -103,6 +111,13 @@ Conditions:
 
     UseDefaultAMI:
       !Equals [ $(ImageId), "" ]
+
+    ScaleOnScheduledJobs:
+      !Equals [ $(AutoscaleStrategy), "scheduledjobs" ]
+
+    ScaleOnCPU:
+      !Equals [ $(AutoscaleStrategy), "cpu" ]
+
 
 Resources:
   # Allow ec2 instances to assume a role and be granted the IAMPolicies


### PR DESCRIPTION
This is the beginning of autoscaling based on the metrics provided by https://github.com/buildkite/buildkite-cloudwatch-metrics-publisher. 

You can specify an `AutoscaleStrategy` of `scheduledjobs` to get this new behaviour.

A future PR will likely bring in the Lambda functions directly into this stack so we have a one-stop-shop.