### PR TITLE
Allow empty secrets key

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ Set your [Agent Query Rules](https://buildkite.com/docs/agent/agent-meta-data) t
 
 ## Secrets
 
-Your stack has access to the `SecretsBucket` parameter you passed in. This should be used in combination with strong encryption to ensure that your CI secrets (such as Github credentials) are reasonably secure. See the [Security](#security) section for more details.
-
-You provide a key via an environment var in your Buildkite config called `BUILDKITE_SECRETS_KEY` which will be used to decrypt all the files found in the secrets bucket.
+Your stack has access to the `SecretsBucket` parameter you passed in. This should be used in combination with server-side object encryption to ensure that your CI secrets (such as Github credentials) are reasonably secure. See the [Security](#security) section for more details.
 
 Two files are specifically looked for, `id_rsa_github`, for checking out your git code and optionally `env`, which contains environment variables to expose to the job command.
+
+By default, builds will look for `s3://{SecretsBucket}/{PipelineSlug}/filename`.  You can override the `{PipelineSlug}` part with the `BUILDKITE_SECRETS_PREFIX` environment variable.
+
+You should encrypt your objects with a project-specific key and provide it in `BUILDKITE_SECRETS_KEY` which will be used to decrypt all the files found in the secrets bucket.
 
 ### Uploading your Secrets
 

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -1,33 +1,44 @@
 #!/bin/bash
-set -eu
+set -eux
 
 s3_exists() {
-  env -i aws s3 ls "s3://${BUILDKITE_SECRETS_BUCKET}/$1" &>/dev/null
+  env -i aws s3 ls "$1" &>/dev/null
 }
 
 s3_download() {
-  env -i aws s3 cp --quiet --sse-c AES256 --sse-c-key "${BUILDKITE_SECRETS_KEY}" "s3://${BUILDKITE_SECRETS_BUCKET}/$1" /dev/stdout
+  local aws_s3_args=("--quiet")
+
+  if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
+    aws_s3_args+=("--sse-c" "AES256" "--sse-c-key" "${BUILDKITE_SECRETS_KEY}")
+  fi
+
+  echo env -i aws s3 cp ${aws_s3_args[@]} "$1" /dev/stdout
 }
 
 echo '+++ :house_with_garden: Setting up the environment'
 
-source ~/cfn-env
-
-if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] && [[ -z "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
-  echo "A SecretsBucket was provided, but no encryption key via BUILDKITE_SECRETS_KEY."
-  exit 1
-fi
-
+eval "$(cat ~/cfn-env)"
 eval "$(ssh-agent -s)"
 
 if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
 
-  echo "Downloading ssh key from $BUILDKITE_SECRETS_BUCKET"
-  ssh-add <(s3_download "${SSH_KEY_NAME:-id_rsa_github}")
+  # allow env to override paths
+  secrets_prefix="${BUILDKITE_SECRETS_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
+  secrets_url_base="s3://${BUILDKITE_SECRETS_BUCKET}/${secrets_prefix}"
+  ssh_key_url="${secrets_url_base}/${SSH_KEY_NAME:-id_rsa_github}"
+  env_url="${secrets_url_base}/env"
 
-  if s3_exists "env" ; then
-     echo "Downloading env from $BUILDKITE_SECRETS_BUCKET"
-    eval "$(s3_download env)"
+  if ! s3_exists "$ssh_key_url" ; then
+    echo "Failed to download $ssh_key_url"
+    exit 1
+  fi
+
+  echo "Downloading ssh key from $ssh_key_url"
+  ssh-add <(s3_download "$ssh_key_url")
+
+  if s3_exists "$env_url" ; then
+    echo "Downloading env from $env_url"
+    eval "$(s3_download $env_url)"
   fi
 fi
 

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -eux
 
 s3_exists() {
   env -i aws s3 ls "$1" --summarize --human-readable

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -1,8 +1,8 @@
 #!/bin/bash
-set -eux
+set -eu
 
 s3_exists() {
-  env -i aws s3 ls "$1" &>/dev/null
+  env -i aws s3 ls "$1" --summarize --human-readable
 }
 
 s3_download() {

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -12,7 +12,7 @@ s3_download() {
     aws_s3_args+=("--sse-c" "AES256" "--sse-c-key" "${BUILDKITE_SECRETS_KEY}")
   fi
 
-  echo env -i aws s3 cp ${aws_s3_args[@]} "$1" /dev/stdout
+  env -i aws s3 cp ${aws_s3_args[@]} "$1" /dev/stdout
 }
 
 echo '+++ :house_with_garden: Setting up the environment'


### PR DESCRIPTION
For easier backwards compatibility with stacks that didn't have encrypted keys in a provision bucket, this allows `BUILDKITE_SECRETS_KEY` to be empty.

It also provides some extra configuration points via ENV:

 - `BUILDKITE_SECRETS_PREFIX` - This is a key prefix for the secrets bucket, by default it's the name of the pipeline
 - `SSH_KEY_NAME` - The name of the key file (under the above prefix), defaults to `id_rsa_github`

This change also sets the default url for env and the ssh key file to be under the above `BUILDKITE_SECRETS_PREFIX`, which is a breaking change. You can set an empty secrets prefix to emulate previous behaviour.


