### PR TITLE
remove old mappings on clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ setup:
 
 clean:
 	-rm build/*
+	-rm templates/mappings.yml
 
 build-ami:
 	cd packer/; packer build buildkite-ami.json


### PR DESCRIPTION
Currently the mappings are not deleted on `make clean`. This means that a `make clean create-stack` does not deploy the latest AMI.