### PR TITLE
Chown the builds before checkout

### DIFF
--- a/packer/conf/buildkite-sudoers.conf
+++ b/packer/conf/buildkite-sudoers.conf
@@ -1,0 +1,1 @@
+buildkite-agent ALL=NOPASSWD: /usr/bin/fix-checkout-permissions

--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -49,3 +49,5 @@ fi
 
 unset BUILDKITE_SECRETS_BUCKET
 unset BUILDKITE_SECRETS_KEY
+
+sudo /usr/bin/fix-checkout-permissions

--- a/packer/conf/scripts/fix-checkout-permissions
+++ b/packer/conf/scripts/fix-checkout-permissions
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+if [[ -e /var/lib/buildkite-agent/builds ]] ; then
+	chown -R  buildkite-agent.buildkite-agent /var/lib/buildkite-agent/builds
+fi

--- a/packer/scripts/install-buildkite.sh
+++ b/packer/scripts/install-buildkite.sh
@@ -18,6 +18,11 @@ if [ -f /etc/init/buildkite-agent.conf ]; then
   sudo cp /usr/share/buildkite-agent/lsb/buildkite-agent.sh /etc/init.d/buildkite-agent
 fi
 
+# Allow buildkite to fix checkout permissions
+sudo cp /tmp/conf/buildkite-sudoers.conf /etc/sudoers.d/buildkite
+sudo chmod 440 /etc/sudoers.d/buildkite
+sudo mv /tmp/conf/scripts/fix-checkout-permissions /usr/bin/
+
 # move custom hooks into place
 chmod +x /tmp/conf/hooks/*
 sudo cp -a /tmp/conf/hooks/* /etc/buildkite-agent/hooks


### PR DESCRIPTION
This PR adds a 
```
chown -R  buildkite-agent.buildkite-agent /var/lib/buildkite-agent/builds
```

before doing a checkout. 

This works around permission issues caused volume mounts leaving files owned by root in the checkout. 

I think the long term aim should be https://github.com/buildkite/buildkite-aws-stack/pull/32, as it fixes the underlying security issue and not just the symptom, but it needs more thorough testing.