### PR TITLE
Scale down much less aggressively

### DIFF
--- a/packer/conf/hooks/environment
+++ b/packer/conf/hooks/environment
@@ -15,7 +15,7 @@ s3_download() {
   env -i aws s3 cp ${aws_s3_args[@]} "$1" /dev/stdout
 }
 
-echo '+++ :house_with_garden: Setting up the environment'
+echo '--- :house_with_garden: Setting up the environment'
 
 eval "$(cat ~/cfn-env)"
 eval "$(ssh-agent -s)"

--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -72,15 +72,15 @@ Resources:
    Type: AWS::CloudWatch::Alarm
    Condition: ScaleOnScheduledJobs
    Properties:
-      AlarmDescription: Scale-down if ScheduledJobs == 0 for 1 minute
-      MetricName: ScheduledJobsCount
+      AlarmDescription: Scale-down if 0 jobs for 30 minutes
+      MetricName: RunningJobsCount
       Namespace: Buildkite
-      Statistic: Average
-      Period: 60
-      EvaluationPeriods: 1
-      Threshold: 1
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 6
+      Threshold: 0
       AlarmActions: [ $(AgentScaleDownPolicy) ]
       Dimensions:
         - Name: Queue
           Value: $(BuildkiteQueue)
-      ComparisonOperator: LessThanThreshold
+      ComparisonOperator: LessThanOrEqualToThreshold


### PR DESCRIPTION
The Autoscaler is currently terminating instances too aggressively, and can get into a state where it is alarming on both scale up and scale down. It is also terminating random instances which could be still running a build.

This changes the scale down rule to "0 jobs in the last 30 minutes" which works around both of these problems.


In the future it would be nice to add metrics for the number of idle agents and scale on that instead of the number of jobs.