### PR TITLE
Bump to docker 1.10

### DIFF
--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -6,7 +6,10 @@ sudo usermod -a -G docker ec2-user
 sudo cp /tmp/conf/docker.conf /etc/sysconfig/docker
 
 # Overwrite the yum packaged docker with the latest
+# Releases can be found at https://github.com/docker/docker/releases
+# shasums can be found at $URL.sha256
 sudo wget https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 -O /usr/bin/docker
+echo 'a8315f0ff661e6a24a8b83743b6a4be87765bd000fab628de1a8c398b84966cc  /usr/bin/docker' | sha256sum -c
 sudo chmod +x /usr/bin/docker
 
 sudo service docker start || ( cat /var/log/docker && false )

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -eu
 
+DOCKER_VERSION=1.10.3
+DOCKER_SHA256=a8315f0ff661e6a24a8b83743b6a4be87765bd000fab628de1a8c398b84966cc
+
 sudo yum update -yq
 sudo yum install -yq docker
 sudo usermod -a -G docker ec2-user
@@ -8,8 +11,9 @@ sudo cp /tmp/conf/docker.conf /etc/sysconfig/docker
 # Overwrite the yum packaged docker with the latest
 # Releases can be found at https://github.com/docker/docker/releases
 # shasums can be found at $URL.sha256
-sudo wget https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 -O /usr/bin/docker
-echo 'a8315f0ff661e6a24a8b83743b6a4be87765bd000fab628de1a8c398b84966cc  /usr/bin/docker' | sha256sum -c
+wget https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION -o /tmp/docker
+echo "$DOCKER_SHA256 /tmp/docker" | sha256sum --check --strict
+sudo cp /tmp/docker /usr/bin/docker
 sudo chmod +x /usr/bin/docker
 
 sudo service docker start || ( cat /var/log/docker && false )

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/bin/bash
+
+set -eu -o pipefail
 
 DOCKER_VERSION=1.10.3
 DOCKER_SHA256=a8315f0ff661e6a24a8b83743b6a4be87765bd000fab628de1a8c398b84966cc

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -13,7 +13,7 @@ sudo cp /tmp/conf/docker.conf /etc/sysconfig/docker
 # Overwrite the yum packaged docker with the latest
 # Releases can be found at https://github.com/docker/docker/releases
 # shasums can be found at $URL.sha256
-wget https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION -o /tmp/docker
+wget https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION -O /tmp/docker
 echo "$DOCKER_SHA256 /tmp/docker" | sha256sum --check --strict
 sudo cp /tmp/docker /usr/bin/docker
 sudo chmod +x /usr/bin/docker

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -3,7 +3,7 @@
 set -eu -o pipefail
 
 DOCKER_VERSION=1.10.3
-DOCKER_SHA256=a8315f0ff661e6a24a8b83743b6a4be87765bd000fab628de1a8c398b84966cc
+DOCKER_SHA256=d0df512afa109006a450f41873634951e19ddabf8c7bd419caeb5a526032d86d
 
 sudo yum update -yq
 sudo yum install -yq docker

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -5,7 +5,11 @@ sudo yum install -yq docker
 sudo usermod -a -G docker ec2-user
 sudo cp /tmp/conf/docker.conf /etc/sysconfig/docker
 
-sudo service docker start
+# Overwrite the yum packaged docker with the latest
+sudo wget https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 -O /usr/bin/docker
+sudo chmod +x /usr/bin/docker
+
+sudo service docker start || ( cat /var/log/docker && false )
 sudo docker info
 
 # installs docker-compose


### PR DESCRIPTION
This splits the docker 1.10.3 version bump out of https://github.com/buildkite/buildkite-aws-stack/pull/32