### PR TITLE
Nested metrics stack

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -60,6 +60,10 @@ cat << EOF > config.json
     "ParameterValue": "$BUILDKITE_AWS_STACK_AGENT_TOKEN"
   },
   {
+    "ParameterKey": "BuildkiteApiAccessToken",
+    "ParameterValue": "$BUILDKITE_AWS_STACK_API_TOKEN"
+  },
+  {
     "ParameterKey": "BuildkiteQueue",
     "ParameterValue": "${queue_name}"
   },

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -15,6 +15,12 @@ Parameters:
     Type: String
     NoEcho: true
 
+  BuildkiteApiAccessToken:
+    Description: A BuildKite API access token for reading queue metrics
+    Type: String
+    NoEcho: true
+    Default: ""
+
   BuildkiteQueue:
     Description: The queue metadata to register the agent with
     Type: String
@@ -88,7 +94,7 @@ Parameters:
   AutoscaleStrategy:
     Type: String
     Description: The strategy to use for autoscaling
-    Default: cpu
+    Default: scheduledjobs
     AllowedValues:
       - cpu
       - scheduledjobs
@@ -117,6 +123,9 @@ Conditions:
 
     ScaleOnCPU:
       !Equals [ $(AutoscaleStrategy), "cpu" ]
+
+    CreateMetricsStack:
+       !Not [ !Equals [ $(BuildkiteApiAccessToken), "" ] ]
 
 Outputs:
   AgentAutoScaleTopic:

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -1,0 +1,14 @@
+
+Resources:
+  MetricsStack:
+    Condition: CreateMetricsStack
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://s3.amazonaws.com/buildkite-cloudwatch-metrics-publisher/master/cloudwatch-metrics-publisher.json
+      Parameters:
+        BuildkiteApiAccessToken: $(BuildkiteApiAccessToken)
+        BuildkiteOrgSlug: $(BuildkiteOrgSlug)
+        KeyName: $(KeyName)
+        QueueName: $(BuildkiteQueue)
+        PollInterval: 15s
+


### PR DESCRIPTION
Rather than relying on an external stack for metrics gathering, this uses a nested stack if a `BuildkiteApiAccessToken` parameter is provided. Due to this, the default scaling strategy can be (the much better)  `scheduledjobs` vs `cpu`.