### PR TITLE
Pass subnets into metrics stack, fixes #42

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-ami:
 upload: build/aws-stack.json
 	aws s3 sync --acl public-read build s3://buildkite-aws-stack/
 
-create-stack: build/aws-stack.json
+create-stack: templates/mappings.yml build/aws-stack.json
 	aws cloudformation create-stack \
 	--output text \
 	--stack-name buildkite-$(shell date +%Y-%m-%d-%H-%M) \

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -125,7 +125,7 @@ Conditions:
       !Equals [ $(AutoscaleStrategy), "cpu" ]
 
     CreateMetricsStack:
-       !Not [ !Equals [ $(BuildkiteApiAccessToken), "" ] ]
+      [ !Not [ !Equals [ $(BuildkiteApiAccessToken), "" ] ] ]
 
 Outputs:
   AgentAutoScaleTopic:

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -125,7 +125,7 @@ Conditions:
       !Equals [ $(AutoscaleStrategy), "cpu" ]
 
     CreateMetricsStack:
-      [ !Not [ !Equals [ $(BuildkiteApiAccessToken), "" ] ] ]
+      !Not [ !Equals [ $(BuildkiteApiAccessToken), "" ] ]
 
 Outputs:
   AgentAutoScaleTopic:

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -11,5 +11,13 @@ Resources:
         KeyName: $(KeyName)
         QueueName: $(BuildkiteQueue)
         PollInterval: 15s
-        VpcId: !If [ "CreateVpcResources", $(Vpc), $(VpcId) ]
-        Subnets: !If [ "CreateVpcResources", [ $(Subnet0), $(Subnet1), $(Subnet2) ], $(Subnets) ]
+        VpcId: !If [
+          "CreateVpcResources",
+          $(Vpc),
+          $(VpcId)
+        ]
+        Subnets: !If [
+          "CreateVpcResources",
+          "$(Subnet0),$(Subnet1),$(Subnet2)",
+          $(Subnets)
+        ]

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -11,8 +11,4 @@ Resources:
         KeyName: $(KeyName)
         QueueName: $(BuildkiteQueue)
         PollInterval: 15s
-        Subnets: !If [
-          "CreateVpcResources",
-          [ $(Subnet0), $(Subnet1), $(Subnet2) ],
-          $Subnets
-        ]
+        Subnets: !If [ "CreateVpcResources", [ $(Subnet0), $(Subnet1), $(Subnet2) ], $(Subnets) ]

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -11,4 +11,5 @@ Resources:
         KeyName: $(KeyName)
         QueueName: $(BuildkiteQueue)
         PollInterval: 15s
+        VpcId: !If [ "CreateVpcResources", $(Vpc), $(VpcId) ]
         Subnets: !If [ "CreateVpcResources", [ $(Subnet0), $(Subnet1), $(Subnet2) ], $(Subnets) ]

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -11,4 +11,8 @@ Resources:
         KeyName: $(KeyName)
         QueueName: $(BuildkiteQueue)
         PollInterval: 15s
-
+        Subnets: !If [
+          "CreateVpcResources",
+          [ $(Subnet0), $(Subnet1), $(Subnet2) ],
+          $Subnets
+        ]

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -19,5 +19,5 @@ Resources:
         Subnets: !If [
           "CreateVpcResources",
           "$(Subnet0),$(Subnet1),$(Subnet2)",
-          $(Subnets)
+          !Join [ ",", $(Subnets) ]
         ]


### PR DESCRIPTION
Previously the created VPC or specified existing subnets weren't being passed down to the metrics stack, leading to failures like #42. 