### PR TITLE
Better agent metadata

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -72,7 +72,7 @@ Resources:
    Type: AWS::CloudWatch::Alarm
    Condition: ScaleOnScheduledJobs
    Properties:
-      AlarmDescription: Scale-down if 0 jobs for 30 minutes
+      AlarmDescription: Scale-down if 0 jobs for 5 minutes
       MetricName: RunningJobsCount
       Namespace: Buildkite
       Statistic: Maximum

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -223,9 +223,7 @@ Resources:
                 chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
             02-install-buildkite:
               command: |
-                #!/bin/bash -eu
-                BUILDKITE_METADATA=\$(sprintf '"queue=%s,docker=%s,stack=%s"' \
-                  $(BuildkiteQueue) \$(docker --version | cut -f3 -d' ' | sed 's/,//')) $(AWS::StackName)
+                export BUILDKITE_METADATA=\$(printf '"queue=%s,docker=%s,stack=%s"' $(BuildkiteQueue) \$(docker --version | cut -f3 -d' ' | sed 's/,//')) $(AWS::StackName)
                 sed -i -r 's/^(name)=.*/\1="$(AWS::StackName)-%hostname-%n"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(token)=.*/\1="$(BuildkiteAgentToken)"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(# )?(meta-data-ec2-tags)=.*/\2=true/' /etc/buildkite-agent/buildkite-agent.cfg

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -223,12 +223,13 @@ Resources:
                 chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
             02-install-buildkite:
               command: |
+                #!/bin/bash -eu
                 BUILDKITE_METADATA=\$(sprintf '"queue=%s,docker=%s,stack=%s"' \
                   $(BuildkiteQueue) \$(docker --version | cut -f3 -d' ' | sed 's/,//')) $(AWS::StackName)
                 sed -i -r 's/^(name)=.*/\1="$(AWS::StackName)-%hostname-%n"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(token)=.*/\1="$(BuildkiteAgentToken)"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(# )?(meta-data-ec2-tags)=.*/\2=true/' /etc/buildkite-agent/buildkite-agent.cfg
-                sed -i -r "s/^(# )?(meta-data)=.*/\2=\$BUILDKITE_METADATA" /etc/buildkite-agent/buildkite-agent.cfg
+                sed -i -r "s/^(# )?(meta-data)=.*/\2=\$BUILDKITE_METADATA/" /etc/buildkite-agent/buildkite-agent.cfg
                 service buildkite-agent start
             03-fetch-authorized-users:
               test: test -n "$(AuthorizedUsersUrl)"

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -223,11 +223,11 @@ Resources:
                 chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
             02-install-buildkite:
               command: |
-                DOCKER_VERSION=$(docker --version | cut -f3 -d' ' | sed 's/,//')
+                BUILDKITE_METADATA=\$(sprintf '"queue=%s,docker=%s"' $(BuildkiteQueue) \$(docker --version | cut -f3 -d' ' | sed 's/,//'))
                 sed -i -r 's/^(name)=.*/\1="$(AWS::StackName)-%hostname-%n"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(token)=.*/\1="$(BuildkiteAgentToken)"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(# )?(meta-data-ec2-tags)=.*/\2=true/' /etc/buildkite-agent/buildkite-agent.cfg
-                sed -i -r "s/^(# )?(meta-data)=.*/\2=\"queue=$(BuildkiteQueue),docker=\$DOCKER_VERSION\"/" /etc/buildkite-agent/buildkite-agent.cfg
+                sed -i -r "s/^(# )?(meta-data)=.*/\2=\$BUILDKITE_METADATA" /etc/buildkite-agent/buildkite-agent.cfg
                 service buildkite-agent start
             03-fetch-authorized-users:
               test: test -n "$(AuthorizedUsersUrl)"

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -223,9 +223,11 @@ Resources:
                 chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
             02-install-buildkite:
               command: |
-                sed -i -r 's/^(name)=.*/\1="$(AWS::StackName)-%n"/' /etc/buildkite-agent/buildkite-agent.cfg
+                DOCKER_VERSION=$(docker --version | cut -f3 -d' ' | sed 's/,//')
+                sed -i -r 's/^(name)=.*/\1="$(AWS::StackName)-%hostname-%n"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(token)=.*/\1="$(BuildkiteAgentToken)"/' /etc/buildkite-agent/buildkite-agent.cfg
-                sed -i -r 's/^(# )?(meta-data)=.*/\2="queue=$(BuildkiteQueue),docker=1.9.1,stack=$(AWS::StackName)"/' /etc/buildkite-agent/buildkite-agent.cfg
+                sed -i -r 's/^(# )?(meta-data-ec2-tags)=.*/\2=true/' /etc/buildkite-agent/buildkite-agent.cfg
+                sed -i -r "s/^(# )?(meta-data)=.*/\2=\"queue=$(BuildkiteQueue),docker=\$DOCKER_VERSION\"/" /etc/buildkite-agent/buildkite-agent.cfg
                 service buildkite-agent start
             03-fetch-authorized-users:
               test: test -n "$(AuthorizedUsersUrl)"

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -223,7 +223,8 @@ Resources:
                 chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
             02-install-buildkite:
               command: |
-                BUILDKITE_METADATA=\$(sprintf '"queue=%s,docker=%s"' $(BuildkiteQueue) \$(docker --version | cut -f3 -d' ' | sed 's/,//'))
+                BUILDKITE_METADATA=\$(sprintf '"queue=%s,docker=%s,stack=%s"' \
+                  $(BuildkiteQueue) \$(docker --version | cut -f3 -d' ' | sed 's/,//')) $(AWS::StackName)
                 sed -i -r 's/^(name)=.*/\1="$(AWS::StackName)-%hostname-%n"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(token)=.*/\1="$(BuildkiteAgentToken)"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(# )?(meta-data-ec2-tags)=.*/\2=true/' /etc/buildkite-agent/buildkite-agent.cfg

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -223,7 +223,7 @@ Resources:
                 chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
             02-install-buildkite:
               command: |
-                export BUILDKITE_METADATA=\$(printf '"queue=%s,docker=%s,stack=%s"' $(BuildkiteQueue) \$(docker --version | cut -f3 -d' ' | sed 's/,//')) $(AWS::StackName)
+                export BUILDKITE_METADATA=\$(printf '"queue=%s,docker=%s,stack=%s"' $(BuildkiteQueue) \$(docker --version | cut -f3 -d' ' | sed 's/,//') $(AWS::StackName))
                 sed -i -r 's/^(name)=.*/\1="$(AWS::StackName)-%hostname-%n"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(token)=.*/\1="$(BuildkiteAgentToken)"/' /etc/buildkite-agent/buildkite-agent.cfg
                 sed -i -r 's/^(# )?(meta-data-ec2-tags)=.*/\2=true/' /etc/buildkite-agent/buildkite-agent.cfg


### PR DESCRIPTION
This changes the agent name pattern to include the hostname `%stackname-%hostname-%n` and adds the correct docker version to the agent metadata, as well as ec2 instance tags. 