### PR TITLE
Docker 1.11.1 + Docker Compose 1.7.0

### DIFF
--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -3,7 +3,7 @@
     {
       "type": "amazon-ebs",
       "region": "us-east-1",
-      "source_ami": "ami-8fcee4e5",
+      "source_ami": "ami-08111162",
       "region": "us-east-1",
       "instance_type": "c4.large",
       "ssh_username": "ec2-user",

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -2,8 +2,8 @@
 
 set -eu -o pipefail
 
-DOCKER_VERSION=1.10.3
-DOCKER_SHA256=d0df512afa109006a450f41873634951e19ddabf8c7bd419caeb5a526032d86d
+DOCKER_VERSION=1.11.1
+DOCKER_SHA256=893e3c6e89c0cd2c5f1e51ea41bc2dd97f5e791fcfa3cee28445df277836339d
 
 sudo yum update -yq
 sudo yum install -yq docker
@@ -13,16 +13,15 @@ sudo cp /tmp/conf/docker.conf /etc/sysconfig/docker
 # Overwrite the yum packaged docker with the latest
 # Releases can be found at https://github.com/docker/docker/releases
 # shasums can be found at $URL.sha256
-wget https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION -O /tmp/docker
-echo "$DOCKER_SHA256 /tmp/docker" | sha256sum --check --strict
-sudo cp /tmp/docker /usr/bin/docker
-sudo chmod +x /usr/bin/docker
+wget https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION.tgz -O /tmp/docker.tgz
+echo "$DOCKER_SHA256 /tmp/docker.tgz" | sha256sum --check --strict
+sudo tar -xz -C /usr/bin --strip-components 1 -f /tmp/docker.tgz
 
 sudo service docker start || ( cat /var/log/docker && false )
 sudo docker info
 
 # installs docker-compose
-sudo curl -o /usr/bin/docker-compose -L https://github.com/docker/compose/releases/download/1.6.2/docker-compose-Linux-x86_64
+sudo curl -o /usr/bin/docker-compose -L https://github.com/docker/compose/releases/download/1.7.0/docker-compose-Linux-x86_64
 sudo chmod +x /usr/bin/docker-compose
 
 # install docker-gc


### PR DESCRIPTION
This updates the Docker version to 1.11.1 (from 1.10.3) and Docker Compose to 1.7.0 (from 1.6.2).

Docker 1.11.0 had some odd bug that would hang on some Docker operations, so it was skipped.

This also updates the base Amazon Linux AMI image to `ami-08111162`