### PR TITLE
Remove CPU based autoscaling

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -16,44 +16,8 @@ Resources:
       Cooldown : 10
       ScalingAdjustment : -1
 
-  CPUAlarmHigh:
-   Type: AWS::CloudWatch::Alarm
-   Condition: ScaleOnCPU
-   Properties:
-      AlarmDescription: Scale-up if CPU > 40% for 5 minutes
-      MetricName: CPUUtilization
-      Namespace: AWS/EC2
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 2
-      Threshold: 40
-      AlarmActions: [ $(AgentScaleUpPolicy) ]
-      Dimensions:
-        - Name: AutoScalingGroupName
-          Value: $(AgentAutoScaleGroup)
-      ComparisonOperator: GreaterThanThreshold
-
-  CPUAlarmLow:
-   Type: AWS::CloudWatch::Alarm
-   Condition: ScaleOnCPU
-   Properties:
-      AlarmDescription: Scale-down if CPU < 5% for 5 minutes
-      MetricName: CPUUtilization
-      Namespace: AWS/EC2
-      Statistic: Average
-      Period: 300
-      EvaluationPeriods: 2
-      Threshold: 5
-      AlarmActions: [ $(AgentScaleDownPolicy) ]
-      Dimensions:
-        - Name: AutoScalingGroupName
-          Value: $(AgentAutoScaleGroup)
-      ComparisonOperator: LessThanThreshold
-
-
   ScheduledJobsAlarmHigh:
    Type: AWS::CloudWatch::Alarm
-   Condition: ScaleOnScheduledJobs
    Properties:
       AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
       MetricName: ScheduledJobsCount
@@ -70,7 +34,6 @@ Resources:
 
   ScheduledJobsAlarmLow:
    Type: AWS::CloudWatch::Alarm
-   Condition: ScaleOnScheduledJobs
    Properties:
       AlarmDescription: Scale-down if 0 jobs for 5 minutes
       MetricName: RunningJobsCount

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -91,14 +91,6 @@ Parameters:
     Description: The AMI to use, otherwise uses the mapping built in
     Default: ""
 
-  AutoscaleStrategy:
-    Type: String
-    Description: The strategy to use for autoscaling
-    Default: scheduledjobs
-    AllowedValues:
-      - cpu
-      - scheduledjobs
-
 Conditions:
     UseSpotInstances:
       !Not [ !Equals [ $(SpotPrice), 0 ] ]
@@ -117,12 +109,6 @@ Conditions:
 
     UseDefaultAMI:
       !Equals [ $(ImageId), "" ]
-
-    ScaleOnScheduledJobs:
-      !Equals [ $(AutoscaleStrategy), "scheduledjobs" ]
-
-    ScaleOnCPU:
-      !Equals [ $(AutoscaleStrategy), "cpu" ]
 
     CreateMetricsStack:
       !Not [ !Equals [ $(BuildkiteApiAccessToken), "" ] ]


### PR DESCRIPTION
It has proven to be an ineffective strategy, so we have decided to remove it and simplify the autoscaling template and configuration params.