### PR TITLE
Added option for ArtifactsBucket to CFN

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ aws cloudformation create-stack \
 | BuildkiteApiAccessToken      | A Buildkite API token for metrics                                    |                 |
 | BuildkiteQueue               | The Buildkite queue to give the agents                               | elastic         |
 | SecretsBucket                | An S3 bucket (and optional prefix) that contains secrets             |                 |
+| ArtifactsBucket              | An S3 bucket (and optional prefix) that contains build artifacts     |                 |
 | InstanceType                 | The EC2 instance size to launch                                      | t2.nano         |
 | MinSize                      | The minimum number of instances to launch                            | 0               |
 | MaxSize                      | The maximum number of instances to launch                            | 10              |
@@ -75,7 +76,7 @@ For Docker Hub credentials, you can use `DOCKER_HUB_USER`, `DOCKER_HUB_PASSWORD`
 
 ## Autoscaling
 
-If you provided a `BuildkiteApiAccessToken`, a Buildkite API token with `read_builds` and `read_agents` permissions across your organiaation, then build and job metrics will be collected for your queue and used to scale your cluster of agents. Autoscaling is designed to scale up quite quickly and then gradually scale down. See [the autoscale.yml template](templates/autoscale.yml) for more details, or the [Buildkite Metrics Publisher](https://github.com/buildkite/buildkite-cloudwatch-metrics-publisher) project for how metrics are collected.
+If you provided a `BuildkiteApiAccessToken`, a Buildkite API token with `read_builds` and `read_agents` permissions across your organization, then build and job metrics will be collected for your queue and used to scale your cluster of agents. Autoscaling is designed to scale up quite quickly and then gradually scale down. See [the autoscale.yml template](templates/autoscale.yml) for more details, or the [Buildkite Metrics Publisher](https://github.com/buildkite/buildkite-cloudwatch-metrics-publisher) project for how metrics are collected.
 
 ## Security
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -1,4 +1,3 @@
-
 ## Provides the infrastructure for a scalable buildkite cluster
 
 Metadata:
@@ -27,6 +26,7 @@ Metadata:
         - KeyName
         - SpotPrice
         - SecretsBucket
+        - ArtifactsBucket
         - AuthorizedUsersUrl
         - RootVolumeSize
         - RootVolumeIops
@@ -65,7 +65,12 @@ Parameters:
     Default: elastic
 
   SecretsBucket:
-    Description: An s3 bucket containing provisioning files
+    Description: An S3 bucket containing provisioning files
+    Type: String
+    Default: ""
+
+  ArtifactsBucket:
+    Description: An S3 bucket containing build artifacts
     Type: String
     Default: ""
 
@@ -145,6 +150,9 @@ Conditions:
     UseSecretsBucket:
       !Not [ !Equals [ $(SecretsBucket), "" ] ]
 
+    UseArtifactsBucket:
+      !Not [ !Equals [ $(ArtifactsBucket), "" ] ]
+
     UseDefaultAMI:
       !Equals [ $(ImageId), "" ]
 
@@ -207,6 +215,23 @@ Resources:
             Resource:
               - "arn:aws:s3:::$(SecretsBucket)/*"
               - "arn:aws:s3:::$(SecretsBucket)"
+      Roles:
+        - $(IAMRole)
+
+  ArtifactsBucketPolicies:
+    Type: AWS::IAM::Policy
+    Condition: UseArtifactsBucket
+    Properties:
+      PolicyName: ArtifactsBucketPolicy
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:Put*
+              - s3:List*
+            Resource:
+              - "arn:aws:s3:::$(ArtifactsBucket)/*"
+              - "arn:aws:s3:::$(ArtifactsBucket)"
       Roles:
         - $(IAMRole)
 
@@ -321,4 +346,3 @@ Resources:
           FromPort: 22
           ToPort: 22
           CidrIp: 0.0.0.0/0
-


### PR DESCRIPTION
This PR adds an optional `ArtifactsBucket` parameter (and associated policies) to the AWS stack.

This is nice for uploading artifacts outside of buildkite agents...