### PR TITLE
Tweaks to makefile for easier setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean build build-ami upload create-stack
+.PHONY: all clean build build-ami upload create-stack update-stack config.json
 
 BUILDKITE_STACK_BUCKET ?= buildkite-aws-stack
 
@@ -27,9 +27,10 @@ build-ami:
 upload: build/aws-stack.json
 	aws s3 sync --acl public-read build s3://${BUILDKITE_STACK_BUCKET}/
 
-create-stack: templates/mappings.yml build/aws-stack.json
+config.json:
 	test -s config.json || { echo "Please create a config.json file"; exit 1; }
 
+create-stack: config.json templates/mappings.yml build/aws-stack.json
 	aws cloudformation create-stack \
 	--output text \
 	--stack-name buildkite \
@@ -43,9 +44,7 @@ validate: build/aws-stack.json
 	--output table \
 	--template-body "file://${PWD}/build/aws-stack.json"
 
-update-stack: templates/mappings.yml build/aws-stack.json
-	test -s config.json || { echo "Please create a config.json file"; exit 1; }
-
+update-stack: config.json templates/mappings.yml build/aws-stack.json
 	aws cloudformation update-stack \
 	--output text \
 	--stack-name buildkite \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ create-stack: config.json templates/mappings.yml build/aws-stack.json
 	--disable-rollback \
 	--template-body "file://${PWD}/build/aws-stack.json" \
 	--capabilities CAPABILITY_IAM \
-	--parameters '$(shell cat config.json)' \
+	--parameters '$(shell cat config.json)'
 
 validate: build/aws-stack.json
 	aws cloudformation validate-template \
@@ -50,5 +50,4 @@ update-stack: config.json templates/mappings.yml build/aws-stack.json
 	--stack-name buildkite \
 	--template-body "file://${PWD}/build/aws-stack.json" \
 	--capabilities CAPABILITY_IAM \
-	--parameters '$(shell cat config.json)' \
-
+	--parameters '$(shell cat config.json)'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 
 .PHONY: all clean build build-ami upload create-stack
+AWS_PROFILE ?= default
+BUILDKITE_STACK_BUCKET ?= buildkite-aws-stack
 
-all: build
+all: setup build
 
 build: build/aws-stack.json
 
@@ -14,30 +16,40 @@ build/aws-stack.json: $(wildcard templates/*.yml)
 	bundle exec cfoo $^ > $@
 
 setup:
-	which bundle || gem install bundler --no-ri --no-rdoc
-	bundle install --path vendor/bundle
+	bundle check || ((which bundle || gem install bundler --no-ri --no-rdoc) && bundle install --path vendor/bundle)
+	cp config.json.example config.json
 
 clean:
-	-rm build/*
-	-rm templates/mappings.yml
+	-rm -f build/*
+	-rm -f templates/mappings.yml
 
 build-ami:
 	cd packer/; packer build buildkite-ami.json
 
 upload: build/aws-stack.json
-	aws s3 sync --acl public-read build s3://buildkite-aws-stack/
+	aws s3 sync --acl public-read build s3://${BUILDKITE_STACK_BUCKET}/
 
 create-stack: templates/mappings.yml build/aws-stack.json
 	aws cloudformation create-stack \
 	--output text \
-	--stack-name buildkite-$(shell date +%Y-%m-%d-%H-%M) \
+	--stack-name buildkite \
 	--disable-rollback \
 	--template-body "file://${PWD}/build/aws-stack.json" \
 	--capabilities CAPABILITY_IAM \
-	--parameters '$(shell cat config.json)'
+	--parameters '$(shell cat config.json)' \
+	--profile "$(AWS_PROFILE)"
 
 validate: build/aws-stack.json
 	aws cloudformation validate-template \
 	--output table \
 	--template-body "file://${PWD}/build/aws-stack.json"
+
+update-stack: templates/mappings.yml build/aws-stack.json
+	aws cloudformation update-stack \
+	--output text \
+	--stack-name buildkite \
+	--template-body "file://${PWD}/build/aws-stack.json" \
+	--capabilities CAPABILITY_IAM \
+	--parameters '$(shell cat config.json)' \
+	--profile "$(AWS_PROFILE)"
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@ aws cloudformation create-stack \
 
 Alternately, if you prefer to use this repo, clone it and run the following command to set up things locally and create a remote stack.
 ```bash
-make && make create-stack
+# To set up your local environment and generate the CFN template JSON
+make
 
-# If you need to specify a profile:
-AWS_PROFILE="SOMETHING" make && make create-stack
+# Or, to set things up locally and create the stack on AWS
+make create-stack
+
+# You can use any of the AWS... environment variables that the aws-cli supports.
+AWS_PROFILE="SOMETHING" make create-stack
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ aws cloudformation create-stack \
   --parameters <(cat config.json)
 ```
 
+
+Alternately, if you prefer to use this repo, clone it and run the following command to set up things locally and create a remote stack.
+```bash
+make && make create-stack
+
+# If you need to specify a profile:
+AWS_PROFILE="SOMETHING" make && make create-stack
+
+```
+
+
 ### Useful Stack Parameters
 
 | Command                      | Description                                                          | Default         |


### PR DESCRIPTION
This PR adds a setup step to the default make target (in case bundle isn't installed, for example), and makes it possible to provide variables to switch AWS profiles and stack JSON publication bucket endpoints.

It also adds a target to update your stack.

I did remove the date stamping of stacks because it made updates difficult. We could cache the value locally or something... or make it a parameter?
