### PR TITLE
Support increments for scaling up and down

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -5,16 +5,16 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
-      Cooldown: 10
-      ScalingAdjustment: 1
+      Cooldown: 300
+      ScalingAdjustment: $(ScaleInAdjustment)
 
   AgentScaleDownPolicy:
     Type : AWS::AutoScaling::ScalingPolicy
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
-      Cooldown : 10
-      ScalingAdjustment : -1
+      Cooldown : 600
+      ScalingAdjustment : $(ScaleOutAdjustment)
 
   ScheduledJobsAlarmHigh:
    Type: AWS::CloudWatch::Alarm
@@ -35,12 +35,12 @@ Resources:
   ScheduledJobsAlarmLow:
    Type: AWS::CloudWatch::Alarm
    Properties:
-      AlarmDescription: Scale-down if 0 jobs for 5 minutes
-      MetricName: RunningJobsCount
+      AlarmDescription: Scale-down if ScheduledJobsCount == 0 for 5 minutes
+      MetricName: ScheduledJobsCount
       Namespace: Buildkite
       Statistic: Maximum
       Period: 300
-      EvaluationPeriods: 6
+      EvaluationPeriods: 1
       Threshold: 0
       AlarmActions: [ $(AgentScaleDownPolicy) ]
       Dimensions:

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -112,12 +112,12 @@ Parameters:
     Default: 0
 
   ScaleOutAdjustment:
-    Description: The number of agents to add on each scale out event
+    Description: The number of agents to add on each scale out event (ScheduledJobsCount > 0 for 1 minute)
     Type: Number
     Default: 5
 
   ScaleInAdjustment:
-    Description: The number of agents to remove on each scale in event
+    Description: The number of agents to remove on each scale in event (ScheduledJobsCount == 0 for 5 minutes)
     Type: Number
     Default: -2
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -36,6 +36,8 @@ Metadata:
         Parameters:
         - MinSize
         - MaxSize
+        - ScaleInAdjustment
+        - ScaleOutAdjustment
         - AutoscaleStrategy
         - BuildkiteApiAccessToken
 
@@ -108,6 +110,16 @@ Parameters:
     Description: The minumum number of agents to launch
     Type: Number
     Default: 0
+
+  ScaleOutAdjustment:
+    Description: The number of agents to add on each scale out event
+    Type: Number
+    Default: 5
+
+  ScaleInAdjustment:
+    Description: The number of agents to remove on each scale in event
+    Type: Number
+    Default: -2
 
   RootVolumeSize:
     Description: Size of EBS volume for root filesystem in GB.


### PR DESCRIPTION
As part of a discussion with @arthens and @sj26, we discovered that the stack scale up fires quicker than instances can actually launch. This slows down individual scale up events with a longer cooldown, but introduces a scale up and down increment so that the stack can still quickly scale up and scale down slowly.