### PR TITLE
Fix inverted scaling policy

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -6,7 +6,7 @@ Resources:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
       Cooldown: 300
-      ScalingAdjustment: $(ScaleInAdjustment)
+      ScalingAdjustment : $(ScaleOutAdjustment)
 
   AgentScaleDownPolicy:
     Type : AWS::AutoScaling::ScalingPolicy
@@ -14,7 +14,7 @@ Resources:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
       Cooldown : 600
-      ScalingAdjustment : $(ScaleOutAdjustment)
+      ScalingAdjustment: $(ScaleInAdjustment)
 
   ScheduledJobsAlarmHigh:
    Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
The scale up policy was configured to remove instances, and the scale down policy was configured to add them.

Introduced in 005807d6d348488aff5796af2b28adb45e23c3d6