### PR TITLE
Use the latest agent tag in the packer hash

### DIFF
--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -5,10 +5,16 @@ mkdir -p build
 
 buildkite-agent artifact download "build/buildkite-lifecycle-agent" build/
 
-packer_hash=$(find packer/ -type f -print0 | xargs -0 sha1sum | cut -b-40 | sort | sha1sum | awk '{print $1}')
-packer_file="${packer_hash}.packer"
+packer_files_sha=$(find packer/ -type f -print0 | xargs -0 sha1sum | awk '{print $1}' | sort | sha1sum | awk '{print $1}')
+echo "Packer files hash is $packer_files_sha"
 
+agent_version_sha=$(curl -f -s https://api.github.com/repos/buildkite/agent/releases/latest | grep -Eo '"tag_name": "(.+)"' | sha1sum | awk '{print $1}')
+echo "Agent version hash is $agent_version_sha"
+
+packer_hash=$(echo "$packer_files_sha" "$agent_version_sha" | sha1sum | awk '{print $1}')
 echo "Packer image hash is $packer_hash"
+
+packer_file="${packer_hash}.packer"
 
 if ! aws s3 cp "s3://${BUILDKITE_AWS_STACK_BUCKET}/${packer_file}" . ; then
   make build-ami | tee "$packer_file"


### PR DESCRIPTION
The current packer build doesn't detect a new buildkite agent being available. This adds the latest agent release tag to the packer hash, so when there's a new tag we'll get a new AMI built and an updated stack JSON.