### PR TITLE
Scale down over 120 minutes

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -1,5 +1,19 @@
 
 Resources:
+  MissingMetricsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      MetricName: ScheduledJobsCount
+      Namespace: Buildkite
+      Statistic: SampleCount
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      Dimensions:
+        - Name: Queue
+          Value: $(BuildkiteQueue)
+      ComparisonOperator: LessThanOrEqualToThreshold
+
   AgentScaleUpPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
@@ -35,12 +49,12 @@ Resources:
   ScheduledJobsAlarmLow:
    Type: AWS::CloudWatch::Alarm
    Properties:
-      AlarmDescription: Scale-down if ScheduledJobsCount == 0 for 5 minutes
+      AlarmDescription: Scale-down if ScheduledJobsCount == 0 for 60 minutes
       MetricName: ScheduledJobsCount
       Namespace: Buildkite
       Statistic: Maximum
-      Period: 300
-      EvaluationPeriods: 1
+      Period: 1200
+      EvaluationPeriods: 3
       Threshold: 0
       AlarmActions: [ $(AgentScaleDownPolicy) ]
       Dimensions:

--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -20,7 +20,7 @@ Resources:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
       Cooldown: 300
-      ScalingAdjustment : $(ScaleOutAdjustment)
+      ScalingAdjustment : $(ScaleUpAdjustment)
 
   AgentScaleDownPolicy:
     Type : AWS::AutoScaling::ScalingPolicy
@@ -28,7 +28,7 @@ Resources:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
       Cooldown : 600
-      ScalingAdjustment: $(ScaleInAdjustment)
+      ScalingAdjustment: $(ScaleDownAdjustment)
 
   ScheduledJobsAlarmHigh:
    Type: AWS::CloudWatch::Alarm

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -115,13 +115,13 @@ Parameters:
     Type: Number
     Default: 0
 
-  ScaleOutAdjustment:
-    Description: The number of agents to add on each scale out event (ScheduledJobsCount > 0 for 1 minute)
+  ScaleUpAdjustment:
+    Description: The number of agents to add on each scale up event (ScheduledJobsCount > 0 for 1 minute)
     Type: Number
     Default: 5
 
-  ScaleInAdjustment:
-    Description: The number of agents to remove on each scale in event (ScheduledJobsCount == 0 for 5 minutes)
+  ScaleDownAdjustment:
+    Description: The number of agents to remove on each scale down event (ScheduledJobsCount == 0 for 5 minutes)
     Type: Number
     Default: -2
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -123,7 +123,7 @@ Parameters:
   ScaleDownAdjustment:
     Description: The number of agents to remove on each scale down event (ScheduledJobsCount == 0 for 5 minutes)
     Type: Number
-    Default: -2
+    Default: -5
 
   RootVolumeSize:
     Description: Size of EBS volume for root filesystem in GB.


### PR DESCRIPTION
This slows down the scale down to larger chunks of instances over 60 minute blocks.