### PR TITLE
bump UpdatePolicy MaxBatchSize from 1 to 5

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -391,7 +391,7 @@ Resources:
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MinInstancesInService: $(MinSize)
-        MaxBatchSize: 1
+        MaxBatchSize: 5
         PauseTime: PT15M
         WaitOnResourceSignals: true
 


### PR DESCRIPTION
One instance at a time takes a very long time to cycle through 60-80 instances after a stack update.

I thought about making this a variable but I know you're trying to avoid too many knobs. I'm thinking 5 will at least work better as a starting point.