### PR TITLE
Publish mappings.yml and aws-stack.json for branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ config.json
 templates/mappings.yml
 vendor/
 .bundle/
+*.bak
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 build/
-packer/packer.output
+packer.output
 config.json
 templates/mappings.yml
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ packer.output: $(shell find packer -type f)
 
 templates/mappings.yml: packer.output
 	cp templates/mappings.yml.template templates/mappings.yml
-	sed -i '' "s/packer_image_id/$(shell grep -Eo 'us-east-1: (ami-.+)' packer.output | cut -d' ' -f2)/" templates/mappings.yml
+	sed -i.bak "s/packer_image_id/$(shell grep -Eo 'us-east-1: (ami-.+)' packer.output | cut -d' ' -f2)/" templates/mappings.yml
 
 build-ami: templates/mappings.yml
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all clean build build-ami upload create-stack update-stack config.json
 
 BUILDKITE_STACK_BUCKET ?= buildkite-aws-stack
+BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 all: setup build
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean build build-ami upload create-stack update-stack config.json download-mappings
+.PHONY: all clean build build-ami upload create-stack update-stack download-mappings
 
 BUILDKITE_STACK_BUCKET ?= buildkite-aws-stack
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
@@ -9,11 +9,6 @@ all: setup build
 
 build: build/aws-stack.json
 
-download-mappings:
-	echo "Downloading templates/mappings.yml for branch ${BRANCH}"
-	curl -Lf -o templates/mappings.yml https://s3.amazonaws.com/buildkite-aws-stack/${BRANCH}/mappings.yml
-	touch templates/mappings.yml
-
 build/aws-stack.json: $(wildcard templates/*.yml) templates/mappings.yml
 	-mkdir -p build/
 	bundle exec cfoo $^ > $@
@@ -23,25 +18,27 @@ setup:
 
 clean:
 	-rm -f build/*
-	-rm -f templates/mappings.yml
-	-rm -f packer/packer.output
 
-packer.output: $(shell find packer -type f)
+templates/mappings.yml:
+	$(error Either run `make build-ami` to build the ami, or `make download-mappings` to download the latest public mappings)
+
+download-mappings:
+	echo "Downloading templates/mappings.yml for branch ${BRANCH}"
+	curl -Lf -o templates/mappings.yml https://s3.amazonaws.com/buildkite-aws-stack/${BRANCH}/mappings.yml
+	touch templates/mappings.yml
+
+build-ami:
 	cd packer/; packer build buildkite-ami.json | tee ../packer.output
-
-templates/mappings.yml: packer.output
 	cp templates/mappings.yml.template templates/mappings.yml
 	sed -i.bak "s/packer_image_id/$(shell grep -Eo 'us-east-1: (ami-.+)' packer.output | cut -d' ' -f2)/" templates/mappings.yml
-
-build-ami: templates/mappings.yml
 
 upload: build/aws-stack.json
 	aws s3 sync --acl public-read build s3://${BUILDKITE_STACK_BUCKET}/
 
 config.json:
-	test -s config.json || { echo "Please create a config.json file"; exit 1; }
+	test -s config.json || $(error Please create a config.json file)
 
-create-stack: config.json templates/mappings.yml build/aws-stack.json
+create-stack: config.json build/aws-stack.json
 	aws cloudformation create-stack \
 	--output text \
 	--stack-name ${STACK_NAME} \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ packer.output: $(shell find packer -type f)
 
 templates/mappings.yml: packer.output
 	cp templates/mappings.yml.template templates/mappings.yml
-	sed -i '' "s/packer_image_id/$(shell grep -Eo 'us-east-1: (ami-.+)' packer/packer.output | cut -d' ' -f2)/" templates/mappings.yml
+	sed -i '' "s/packer_image_id/$(shell grep -Eo 'us-east-1: (ami-.+)' packer.output | cut -d' ' -f2)/" templates/mappings.yml
 
 build-ami: templates/mappings.yml
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ aws cloudformation create-stack \
 Alternately, if you prefer to use this repo, clone it and run the following command to set up things locally and create a remote stack.
 
 ```bash
-# To set up your local environment and generate the CFN template JSON
-make setup build
+# To set up your local environment and build a template based on public AMIs
+make setup download-mappings build
 
 # Or, to set things up locally and create the stack on AWS
 make create-stack

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Alternately, if you prefer to use this repo, clone it and run the following comm
 
 ```bash
 # To set up your local environment and generate the CFN template JSON
-make
+make setup build
 
 # Or, to set things up locally and create the stack on AWS
 make create-stack

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 mkdir -p build
-
 buildkite-agent artifact download "build/buildkite-lifecycle-agent" build/
 
 packer_files_sha=$(find packer/ -type f -print0 | xargs -0 sha1sum | awk '{print $1}' | sort | sha1sum | awk '{print $1}')

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -2,9 +2,8 @@
 set -eu
 
 image_id=$(buildkite-agent meta-data get image_id)
-branch=$(git rev-parse --abbrev-ref HEAD)
 
-echo "Publishing branch $branch"
+echo "Publishing branch $BUILDKITE_BRANCH"
 
 cat << EOF > templates/mappings.yml
 Mappings:
@@ -14,10 +13,10 @@ EOF
 
 make setup build
 
-if [[ $branch == "master" ]] ; then
+if [[ $BUILDKITE_BRANCH == "master" ]] ; then
 	aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/mappings.yml"
 	aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/aws-stack.json"
 else
-	aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/${branch}/mappings.yml"
-	aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/${branch}/aws-stack.json"
+	aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/mappings.yml"
+	aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/aws-stack.json"
 fi

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -2,6 +2,9 @@
 set -eu
 
 image_id=$(buildkite-agent meta-data get image_id)
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+echo "Publishing branch $branch"
 
 cat << EOF > templates/mappings.yml
 Mappings:
@@ -10,5 +13,11 @@ Mappings:
 EOF
 
 make setup build
-aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/mappings.yml"
-aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/aws-stack.json"
+
+if [[ $branch == "master" ]] ; then
+	aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/mappings.yml"
+	aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/aws-stack.json"
+else
+	aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/${branch}/mappings.yml"
+	aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/${branch}/aws-stack.json"
+fi

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -16,7 +16,7 @@ make setup build
 if [[ $BUILDKITE_BRANCH == "master" ]] ; then
 	aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/mappings.yml"
 	aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/aws-stack.json"
-else
-	aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/mappings.yml"
-	aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/aws-stack.json"
 fi
+
+aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/mappings.yml"
+aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/aws-stack.json"

--- a/ci/steps.sh
+++ b/ci/steps.sh
@@ -51,7 +51,6 @@ steps:
 
   - command: ci/publish.sh
     name: "Publishing :cloudformation: stack"
-    branches: master
     agents:
       queue: aws-stack
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -80,10 +80,6 @@ cat << EOF > config.json
     "ParameterValue": "${BUILDKITE_AWS_STACK_BUCKET}"
   },
   {
-    "ParameterKey": "ImageId",
-    "ParameterValue": "${image_id}"
-  },
-  {
     "ParameterKey": "VpcId",
     "ParameterValue": "${vpc_id}"
   },
@@ -98,7 +94,13 @@ cat << EOF > config.json
 ]
 EOF
 
-make setup clean build validate
+cat << EOF > templates/mappings.yml
+Mappings:
+  AWSRegion2AMI:
+    us-east-1     : { AMI: $image_id }
+EOF
+
+make setup build validate
 
 echo "--- Creating stack $stack_name"
 aws cloudformation create-stack \

--- a/packer/scripts/install-buildkite.sh
+++ b/packer/scripts/install-buildkite.sh
@@ -9,7 +9,7 @@ gpgcheck=0
 priority=1
 EOF
 
-sudo yum -y install buildkite-agent
+sudo yum -y -q install buildkite-agent
 sudo usermod -a -G docker buildkite-agent
 
 # Allow buildkite to fix checkout permissions

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -5,8 +5,8 @@ set -eu -o pipefail
 DOCKER_VERSION=1.11.1
 DOCKER_SHA256=893e3c6e89c0cd2c5f1e51ea41bc2dd97f5e791fcfa3cee28445df277836339d
 
-sudo yum update -yq
-sudo yum install -yq docker
+sudo yum update -y -q
+sudo yum install -y -q docker
 sudo usermod -a -G docker ec2-user
 sudo cp /tmp/conf/docker.conf /etc/sysconfig/docker
 

--- a/templates/mappings.yml.template
+++ b/templates/mappings.yml.template
@@ -1,0 +1,3 @@
+Mappings:
+  AWSRegion2AMI:
+    us-east-1     : { AMI: packer_image_id }


### PR DESCRIPTION
This changes how `templates/mappings.yml` is pulled down, previously in development it was easy to accidentally use the master AMIs and end up with a mixed result. This now allows for a easier workflow when on a branch. 

Now to create a stack locally, you need to either run `make download-mappings` first or `make build-ami`. 