### PR TITLE
Scale down base on idle workers

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -23,14 +23,14 @@ Resources:
       ScalingAdjustment : $(ScaleUpAdjustment)
 
   AgentScaleDownPolicy:
-    Type : AWS::AutoScaling::ScalingPolicy
+    Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
-      Cooldown : 600
+      Cooldown : 60
       ScalingAdjustment: $(ScaleDownAdjustment)
 
-  ScheduledJobsAlarmHigh:
+  AgentUtilizationAlarmHigh:
    Type: AWS::CloudWatch::Alarm
    Properties:
       AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
@@ -46,14 +46,14 @@ Resources:
           Value: $(BuildkiteQueue)
       ComparisonOperator: GreaterThanThreshold
 
-  ScheduledJobsAlarmLow:
+  AgentUtilizationAlarmLow:
    Type: AWS::CloudWatch::Alarm
    Properties:
-      AlarmDescription: Scale-down if ScheduledJobsCount == 0 for 60 minutes
-      MetricName: ScheduledJobsCount
+      AlarmDescription: Scale-down if BusyAgentCount == 0 for the last 6 minutes, every 2 minutes
+      MetricName: BusyAgentCount
       Namespace: Buildkite
       Statistic: Maximum
-      Period: 1200
+      Period: 120
       EvaluationPeriods: 3
       Threshold: 0
       AlarmActions: [ $(AgentScaleDownPolicy) ]

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -39,7 +39,6 @@ Metadata:
         - MaxSize
         - ScaleInAdjustment
         - ScaleOutAdjustment
-        - AutoscaleStrategy
 
 Parameters:
   KeyName:
@@ -121,9 +120,9 @@ Parameters:
     Default: 5
 
   ScaleDownAdjustment:
-    Description: The number of agents to remove on each scale down event (ScheduledJobsCount == 0 for 5 minutes)
+    Description: The number of agents to remove on each scale down event (BusyAgentCount == 0 for the last 6 minutes, every 2 minutes)
     Type: Number
-    Default: -5
+    Default: -1
 
   RootVolumeSize:
     Description: Size of EBS volume for root filesystem in GB.


### PR DESCRIPTION
This scales down one agent when all agents were idle for 6 minutes, repeating every 2 minutes.  

The old logic would scale down 5 agents if there were no *waiting* for an hour, every 10 minutes.

The scheduled agents check is broken because during normal operation there often arent any scheduled builds, and during quiet (lower than usual, but still active) periods the cluster will scale to zero. This is made worse by the 10 minute cooldown after scaling, which prevents new machines from coming up.

We were seeing this scale down behaviour over lunch. To add insult to injury it means every docker cache is now totally cold, so builds after lunch can take 20+ minutes longer than they should.

A few tweaks to the scale down behaviour:
 - much lower cooldown, scaling down would prevent scaling up for 10 minutes, after scaling to zero this means builds spend a lot of time with zero agents, waiting.
 - scale down in smaller increments more often, ties into a lower cooldown

see https://github.com/buildkite/buildkite-aws-stack/issues/58

before:
![annotated-bk-scaledown](https://cloud.githubusercontent.com/assets/2247982/15597199/389db264-2411-11e6-8f5c-928b997926a9.png)

after:
![2016-05-27_1190x603](https://cloud.githubusercontent.com/assets/2247982/15597206/484d89c8-2411-11e6-932e-81fee0f6839c.png)

I don't think this is perfect, as it leaves our machines a little underutilized but I think simply tweaking the max agents will help a lot. An alternative would be to do scaling based on the percentage of busy agents, but there is also docker cache reusue to think about. keeping a fairly stable number of machines during the day is a big win for performance.